### PR TITLE
Add 2026 CSDN AI coding tools comparison template

### DIFF
--- a/scripts/templates/csdn-ai-coding-tools-comparison-2026.md
+++ b/scripts/templates/csdn-ai-coding-tools-comparison-2026.md
@@ -1,0 +1,352 @@
+> **本文首发于 [maoxunxing.com](https://maoxunxing.com/zh-cn/ai-coding-tools-comparison-2026/)**，转载请注明出处。更多 AI 编程与工程实践文章，欢迎访问我的博客。
+
+---
+
+# AI Coding 选哪一家？2026 全面对比指南
+
+## 引言：为什么我推荐 ChatGPT Pro / Gemini Advanced Pro
+
+2026 年的 AI coding 工具市场已经高度成熟，但也异常混乱。Cursor、Claude Code、GitHub Copilot、Windsurf、OpenCode、Zenmux... 每个工具都在推销自己的订阅，但实际上，**对于大多数开发者来说，最明智的选择是 ChatGPT Pro（$200/月）或 Gemini Advanced Pro（$20-30/月）**。
+
+原因很简单：**量大管饱、成本可控、通用性强**。
+
+本文将从真实成本、使用场景、隐藏费用、封禁风险等维度，帮你理解为什么 Pro 会员是更优解，以及如何配合各种编程工具实现最佳效果。
+
+---
+
+## 一、国际主流 AI Coding 工具盘点
+
+### 1. Cursor - AI 原生 IDE 的代表
+
+**定价：**
+
+- Hobby（免费版）：$0，有限的 agent 请求和 tab 补全
+- Pro：$20/月（年付 $16/月），$20 credit pool
+- Pro+：$60/月，$60 credit pool（3倍）
+- Ultra：$200/月，20倍 credit
+- Teams：$40/用户/月
+
+**核心特点：**
+
+- 基于 VS Code fork，深度集成 AI
+- 2025 年中从请求制改为 credit 制
+- Auto 模式在所有付费计划中**无限使用**（这是关键卖点）
+- 支持 15+ 模型，但通过 Cursor 代理，大多数模型不支持 BYOK（自带密钥）
+
+**适合人群：** 想要 AI 深度集成到编辑器的开发者，日常 inline 补全和快速编辑
+
+**真实成本警告：** credit 制意味着不同模型消耗不同，frontier 模型（如 GPT-4o、Claude Opus）消耗更快。重度用户月均花费 $60-200
+
+---
+
+### 2. Claude Code - 终端 AI Agent 的王者（但有封禁风险⚠️）
+
+**定价：**
+
+- Pro（需 Claude 订阅）：$20/月，每 5 小时窗口约 44,000 tokens
+- Max 5x：$100/月，每 5 小时窗口约 88,000 tokens
+- Max 20x：$200/月，每 5 小时窗口约 220,000 tokens
+- API 按量付费：Sonnet 4.6 ($3/$15 per MTok)，Opus 4.6 ($5/$25 per MTok)
+
+**核心特点：**
+
+- 终端 CLI 工具，无 GUI
+- Claude Opus 4.6 在 SWE-bench Verified 上得分 80.9%，历史最高
+- 自主 agent 循环（plan → edit → test → fix）业界最佳
+- **仅限 Claude 模型**，不支持第三方模型
+- 无本地模型选项
+
+**⚠️ 封禁风险（重要）：**
+
+**2025-2026 年大规模封禁事件：**
+
+- Anthropic 在 2025 年下半年封禁了 **145 万账号**
+- 申诉成功率仅 **3.3%**（52,000 申诉中仅 1,700 成功）
+- 多个用户在充值 Claude Code Max 后**立即被封禁**
+
+**封禁的主要原因：**
+
+1. **地理和 IP 不匹配**
+   - 使用商业 VPN 或共享 IP
+   - 账号注册地与实际使用地不一致
+   - 付款时 IP 地址异常
+
+2. **支付方式风险**
+   - 虚拟信用卡、预付费卡被标记为高风险
+   - 加密货币兑换服务发行的卡
+   - 卡名与账号名不匹配
+   - 曾与被封禁账号关联的支付卡
+
+3. **第三方工具检测**
+   - 2026 年 1 月起，Anthropic 开始封禁通过订阅凭证使用第三方工具的行为
+   - OpenCode、Cline 等通过 Claude Pro/Max 账号代理请求的工具被重点打击
+   - 许多使用这些工具数月的用户在付款后**立即被封**
+
+4. **自动欺诈检测误判**
+   - 升级套餐（Pro → Max）触发安全审查
+   - 更换信用卡或从新设备付款
+   - 多次付款失败后成功
+
+5. **账单系统同步错误**
+   - Claude Code 和 Claude.ai 使用不同的账单系统
+   - 升级或续费时可能出现短暂不同步
+   - 被误判为"逾期付款"而封禁
+
+**封禁后的现实：**
+
+- 付款后几分钟内账号被禁用
+- 显示 "This organization has been disabled" 或 "Your account has been disabled"
+- **不提供退款**（如果判定为违反条款）
+- 申诉处理需要数天到数周
+
+**降低封禁风险的建议：**
+
+- ✅ 使用真实信用卡（来自支持的国家）
+- ✅ 保持一致的 IP 地址（避免频繁切换 VPN）
+- ✅ 避免使用第三方工具代理订阅凭证
+- ✅ 考虑使用 API 方式（无地理限制，封禁风险低）
+- ❌ 不要使用虚拟信用卡或预付费卡
+- ❌ 不要在注册后立即申请使用
+
+**适合人群：** 需要最强推理能力的复杂重构任务，**但需承担封禁风险**
+
+**真实成本警告：** $20 的 Pro 计划限制很大，重度用户基本需要 $100-200/月的 Max 计划，且有封禁风险
+
+---
+
+### 3. GitHub Copilot - 性价比之王
+
+**定价：**
+
+- Free：$0，50 次 premium 请求/月，2000 次补全/月
+- Pro：$10/月（年付 $100/年），300 次 premium 请求/月，无限补全
+- Pro+：$39/月（年付 $390/年），1500 次 premium 请求/月
+- Business：$19/用户/月，300 次 premium 请求/用户/月
+- Enterprise：$39/用户/月，1000 次 premium 请求/用户/月
+- **超额费用：$0.04/次 premium 请求**
+
+**核心特点：**
+
+- **$10/月是全场最具性价比的选择**
+- 支持多模型，包括 Claude Opus 4.6
+- 集成语音插件（本地模型，识别率极高）
+- 自动读取 Claude Desktop 的 MCP 配置
+- VS Code 和 JetBrains 插件形式，非独立 IDE
+
+**为什么它曾经是“低成本用 Opus 4.6”的最佳入口：**
+
+- 相比直接购买 Claude Max（$100-$200/月），Copilot 订阅门槛更低
+- 对很多开发者来说，只需维持 Copilot 订阅，就能在日常 IDE 流程里调用高质量模型
+- 在“代码补全 + 聊天 + 多模型”的一体化体验上，Copilot 的学习成本和迁移成本都很低
+
+**当前限制（重要）：**
+
+- 近期不少用户反馈 **GitHub Copilot 出现订阅受限/无法新开通** 的情况（通常与地区、支付方式、账号风控策略有关）
+- 这意味着“低成本用 Claude Opus 4.6”的路径在现实中可能并不稳定，尤其是新账号
+- 如果你当前无法订阅，可考虑以下替代方案：
+  1. 使用 API 网关方案（如 Zenmux/OpenRouter 类）按量调用 Claude 模型
+  2. 使用 Gemini Advanced Pro 或 ChatGPT Pro 作为主力，再配合编辑器插件
+  3. 团队场景优先评估 Business/Enterprise 采购通道，而非个人订阅路径
+
+**适合人群：** 预算敏感的个人开发者、已在使用 VS Code 的团队
+
+**真实成本与可用性警告：** 超出额度的请求按 $0.04/次收费，重度使用可能意外超标；且在部分地区/账号条件下，订阅可用性本身也可能成为主要风险。
+
+---
+
+### 4. Windsurf - Cursor 的直接竞争者
+
+**定价（2026年3月19日改版后）：**
+
+- Free：$0，有限配额
+- Pro：$20/月（原价 $15），每日/每周配额
+- Teams：$40/席位/月（原价 $30）
+- Max：$200/月（新增），最高配额
+- Enterprise：定制
+
+**核心特点：**
+
+- 2026 年 3 月从 credit 制改为配额制（争议较大）
+- 所有模型可用
+- "Cascade" 模式（类似 Cursor 的 composer）
+- 倾向于过度解释，消耗请求更快
+
+**适合人群：** 喜欢 Windsurf 工作流的开发者
+
+**真实成本警告：** 配额制意味着即使付费，也可能在一天内被限制。老用户享受原价保护
+
+---
+
+### 5. Zenmux - 统一 AI API 网关
+
+**定价：**
+
+- Free：$0，有限额度
+- Builder：$20/月，固定月费 + Flows（浮动价值）
+- Pro：$100/月，更高额度
+- Max：$200/月，最高额度
+- Pay-as-you-go：按实际使用量付费，1 Credit = $1 USD
+
+**核心特点：**
+
+- **统一 AI API 网关**：一个接口访问所有主流模型（OpenAI、Anthropic、Google 等）
+- **Flows 计费模式**：不同于固定 credit，Flows 有浮动的美元等值
+- **无速率限制**（无限扩展）
+- **企业级稳定性 + AI 保险**
+- **Token 级别计费**：用多少付多少
+- 适合：个人开发者、学习、Vibe Coding、生产环境
+
+**适合人群：**
+
+- 需要灵活访问多个模型提供商的开发者
+- 希望简化 API 管理的团队
+- 需要生产级别稳定性的项目
+
+**真实成本警告：** Flows 的浮动价值意味着实际成本可能随模型定价变化，需要密切关注账单
+
+---
+
+### 6. OpenCode - 开源自由的代表
+
+**定价：**
+
+- 工具本身：**完全免费（MIT 开源）**
+- API 使用：通常 $5-50/月（取决于用量和模型选择）
+- 本地模型（Ollama）：**成本为零**
+
+**核心特点：**
+
+- 终端 TUI/CLI，也有桌面应用和 VS Code 扩展
+- 支持 **75+ 模型提供商**（Anthropic、OpenAI、Google、Groq、Ollama 等）
+- 可在对话中切换模型（`/model` 命令）
+- MCP 支持 + 25+ 生命周期钩子的插件系统
+- 无遥测、无数据存储，配合 Ollama 可实现代码完全本地化
+- 支持多会话并行
+
+**⚠️ 注意：** 2026 年 2 月起，Anthropic 开始封禁通过第三方工具（包括 OpenCode）使用 Claude 订阅凭证的行为，建议使用 API 方式而非订阅代理
+
+**适合人群：** 预算敏感团队、需要模型灵活性、有合规/隐私要求的场景
+
+**真实成本警告：** 工具免费，但 API 费用自理。重度使用 Claude Opus 等高端模型时，API 费用可能超过订阅制工具
+
+---
+
+### 7. OpenAI Codex CLI - OpenAI 的终端方案
+
+**定价：**
+
+- 工具本身：免费（Apache 2.0 开源）
+- ChatGPT Plus：$20/月，33-168 条本地消息
+- ChatGPT Pro：$200/月，300-1,500 条消息
+- API 按量付费：codex-mini ($1.50/$6.00 per MTok)，GPT-5 ($1.25/$10.00 per MTok)
+
+**核心特点：**
+
+- **比 Claude Code 约 4 倍更节省 token**（官方宣称）
+- Terminal-Bench 2.0 得分 77.3%
+- 开源，无供应商锁定
+- 可通过 ChatGPT 订阅或 API 密钥使用
+
+**适合人群：** 已订阅 ChatGPT 的开发者、需要 token 效率的场景
+
+---
+
+## 二、为什么 ChatGPT Pro / Gemini Advanced Pro 是最优解
+
+### 核心优势：量大管饱，成本可控
+
+这里的关键不是模型参数本身，而是**“按月固定成本换稳定产能”**。
+
+### 1) Pro 订阅给你的是“可持续开发速度”
+
+如果你每天都在写代码、改 bug、做重构，最大的痛点不是“某个模型不够强”，而是：
+
+- 配额不够，关键时候被限流
+- 按调用计费，月底账单不可控
+- 工具切换频繁，上下文断裂
+
+ChatGPT Pro / Gemini Advanced Pro 在这个层面优势非常明显：
+
+- 成本固定，便于预算管理
+- 日常 coding 问答、重构、排查都能覆盖
+- 能和 IDE / CLI / API 工具形成组合拳
+
+### 2) 组合策略比“单工具信仰”更重要
+
+实践里最稳妥的方式通常是：
+
+- 主力：ChatGPT Pro 或 Gemini Advanced Pro（负责高频交互）
+- 辅助：Copilot / Cursor（负责编辑器内体验）
+- 专项：Claude Code / OpenCode（处理复杂 agent 任务）
+
+也就是说，不要把所有任务压在一个工具上，而是按任务类型做分层。
+
+---
+
+## 三、选型建议（按人群）
+
+### 个人开发者（预算敏感）
+
+- 首选：GitHub Copilot Pro（$10/月）
+- 进阶：Gemini Advanced Pro（$20-30/月）
+- 需要终端 agent：OpenCode + API（按量控制）
+
+### 自由职业 / 小团队
+
+- 首选：ChatGPT Pro 或 Gemini Advanced Pro 作为主力
+- 编辑器协作：Cursor Pro 或 Copilot Business
+- 关键任务保底：准备一个 API 网关方案（如 Zenmux）
+
+### 重度工程团队
+
+- 不建议只靠单一订阅工具
+- 应配置：订阅制 + API 制双通道
+- 对 Claude 生态有依赖时，务必评估账号风控与封禁应急预案
+
+---
+
+## 四、结论
+
+如果你问“2026 年 AI coding 到底该买谁”，我的答案依旧是：
+
+- **大多数人：先买 ChatGPT Pro 或 Gemini Advanced Pro**
+- 再根据你的工作流补一个编辑器工具（Copilot / Cursor）
+- 复杂任务才引入重型 agent（Claude Code / OpenCode）
+
+因为真正影响生产力的，不是某一次 benchmark 的领先，而是：
+
+- 你每周能否稳定输出
+- 你的成本是否可控
+- 你的账号体系是否安全
+
+**选对组合，而不是押注单点，才是 2026 年 AI Coding 的最优解。**
+
+---
+
+如果你希望，我可以下一篇继续写：
+
+- ChatGPT Pro + Copilot 的实战工作流（从需求到 PR）
+- Gemini + OpenCode 的低成本替代方案
+- 团队级 AI coding 预算模型（按人效和调用量拆分）
+
+---
+
+如果你对 AI 编程工作流感兴趣，可以继续阅读：
+
+- [AI Coding 实战手册：工具选型、工作流与提示词模板](https://maoxunxing.com/zh-cn/ai-coding-practice/)
+- [Claude Code vs Cursor：终端 Agent 与 IDE Agent 怎么选](https://maoxunxing.com/zh-cn/claude-code-vs-cursor/)
+
+---
+
+**作者**：Felix Mao（毛毛星）  
+**博客**：[maoxunxing.com](https://maoxunxing.com)  
+**GitHub**：[github.com/XingMXTeam](https://github.com/XingMXTeam/)  
+**Twitter/X**：[@maoxunxing](https://twitter.com/maoxunxing)
+
+---
+
+> CSDN 发布设置建议：
+> - 标题：AI Coding 选哪一家？2026 全面对比指南
+> - 摘要：从成本、配额、封禁风险与工作流组合出发，系统对比 2026 年主流 AI 编程工具，并给出可落地选型建议。
+> - 标签：AI 编程、ChatGPT、Gemini、Copilot、Cursor、Claude Code
+> - 原文链接：https://maoxunxing.com/zh-cn/ai-coding-tools-comparison-2026/


### PR DESCRIPTION
### Motivation
- Add a comprehensive 2026 comparison article to the repository to serve as a template for CSDN publication and documentation. 
- Capture up-to-date vendor/pricing/workflow guidance and highlight recommended subscriptions like `ChatGPT Pro` and `Gemini Advanced Pro`. 
- Provide practical selection and risk-mitigation advice (e.g., account/ban risks and cost traps) for developers and teams.

### Description
- Add a new markdown template at `scripts/templates/csdn-ai-coding-tools-comparison-2026.md` containing a full-length guide and tool-by-tool comparisons for major AI coding tools. 
- The article includes detailed sections for Cursor, Claude Code, GitHub Copilot, Windsurf, Zenmux, OpenCode, OpenAI Codex CLI, selection recommendations by user type, and CSDN publishing notes. 
- The change is content-only and introduces no code or behavioral changes to existing scripts or runtime logic. 
- The file also contains metadata and suggested publishing fields for CSDN (title, summary, tags, original link).

### Testing
- Ran `markdownlint` on the new file to validate markdown style and found no linting errors. 
- No unit tests were added because this is a documentation/template addition and does not affect runtime code or functionality.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eac29dcea0832d83a5a25d4596eff4)