### PR TITLE
Add distribution templates and Chinese index for "AI CLI era" note

### DIFF
--- a/content/notes/ai-cli-era/distribution/csdn-template.zh-cn.md
+++ b/content/notes/ai-cli-era/distribution/csdn-template.zh-cn.md
@@ -1,0 +1,115 @@
+> This article was originally published on [maoxunxing.com](https://maoxunxing.com).
+>
+# AI 时代，我们到底应该用什么命令行工具？（CSDN 发布模板）
+
+> 适用平台：CSDN 博客  
+> 文章定位：观点型 + 工具选型指南  
+> 目标读者：前端/后端/全栈开发者、AI 编程工具重度用户
+
+## 一句话摘要
+AI 时代，命令行不再只是“敲命令”，而是开发入口；与其争论“哪个终端最好”，不如按 **终端 / Shell / 工作流工具 / AI 能力** 四层来设计自己的工具链。
+
+---
+
+## 开场（可直接用）
+今天想聊一个程序员每天都在用、但经常被低估的东西：**命令行工具**。
+
+以前常见组合是 **iTerm2 + Oh My Zsh**，稳定好用；但现在我们会在终端里跑项目、看日志、调 Git、调用 Codex / Claude Code / Gemini CLI，甚至直接让 AI 改代码。
+
+所以问题变成了：
+
+**AI 时代，我们到底该怎么选命令行工具？**
+
+---
+
+## 核心观点（可直接用）
+我现在的建议是：别只选一个工具，而是按 4 层搭工作流：
+
+1. **终端模拟器**：iTerm2 / Ghostty / Warp
+2. **Shell**：Zsh / Fish / Bash
+3. **工作流工具**：tmux / LazyGit / fzf / ripgrep
+4. **AI 能力层**：Warp AI / Codex / Claude Code / Gemini CLI
+
+这样你的工具链更可替换、也更抗变化。
+
+---
+
+## 工具点评（精简版）
+### 1) iTerm2
+- 优点：成熟稳定、分屏和快捷键体系完善
+- 缺点：AI 原生能力弱
+- 适合：稳定优先、少折腾的人
+
+### 2) Oh My Zsh
+- 优点：上手快，插件生态成熟
+- 缺点：插件堆多后启动慢
+- 建议：只保留高价值插件（git / autosuggestions / syntax highlighting）
+
+### 3) Fish
+- 优点：开箱即用，自动建议+语法高亮体验好
+- 缺点：非完全 POSIX 兼容
+- 建议：交互用 Fish，脚本用 Bash/Zsh
+
+### 4) Ghostty
+- 优点：轻量、快、原生感强
+- 缺点：不强调内置 AI
+- 适合：追求性能和可控工作流
+
+### 5) Warp
+- 优点：AI 原生终端，错误解释/命令生成友好
+- 缺点：更重，工作流更“有观点”
+- 适合：想把终端当 AI 工作台的人
+
+### 6) tmux
+- 优点：远程开发和长任务神器（detach/reattach）
+- 缺点：学习曲线陡
+- 结论：本地可选，远程高频场景必备
+
+### 7) LazyGit
+- 优点：高频 Git 操作效率非常高
+- 注意：它不是 Git 基础替代品，而是效率放大器
+
+---
+
+## 推荐组合（可直接用）
+### A. 稳定保守型
+**iTerm2 + Oh My Zsh + LazyGit**
+
+### B. 轻量高效型
+**Ghostty + Fish + LazyGit**
+
+### C. AI 原生型
+**Warp + AI Agent + LazyGit**
+
+---
+
+## 我的结论（可直接用）
+- 普通开发者继续用 iTerm2，完全没问题。  
+- 想要更轻更现代，优先试 Ghostty。  
+- 想要 AI 深度集成，就试 Warp。  
+- Shell 不想折腾就选 Fish；已经熟悉 Zsh 就别强换。  
+- Git 层建议都装 LazyGit。  
+- tmux 按需上，不要盲目追“全家桶”。
+
+---
+
+## CSDN 发布优化建议（模板）
+- 分类：开发工具 / 程序员成长 / AI 编程
+- 标签建议：`命令行` `终端工具` `AI编程` `Warp` `Ghostty` `Fish` `OhMyZsh` `LazyGit` `tmux`
+- 封面文案建议：
+  - 「AI 时代命令行工具怎么选？一文讲透 3 套方案」
+  - 「别再只问哪个终端最好：命令行 4 层工作流指南」
+- 结尾互动话术：
+  - 你现在主力终端是 iTerm2、Ghostty 还是 Warp？
+  - 你会把 AI 放在终端里，还是放在编辑器里？
+
+---
+
+## 参考链接（按需保留）
+- iTerm2: https://iterm2.com/features.html
+- Oh My Zsh: https://ohmyz.sh/
+- Fish: https://fishshell.com/docs/current/
+- Ghostty: https://ghostty.org/
+- Warp: https://www.warp.dev/
+- tmux: https://github.com/tmux/tmux/wiki
+- LazyGit: https://github.com/jesseduffield/lazygit

--- a/content/notes/ai-cli-era/distribution/devto-template.en.md
+++ b/content/notes/ai-cli-era/distribution/devto-template.en.md
@@ -1,0 +1,110 @@
+> This article was originally published on [maoxunxing.com](https://maoxunxing.com).
+>
+# What CLI setup should we use in the AI era? (DEV.to Template)
+
+> Platform: DEV Community  
+> Positioning: opinionated engineering workflow post  
+> Audience: developers using AI coding tools in daily work
+
+## TL;DR
+In the AI era, the terminal is no longer just where we type commands — it is the entry point to development. Instead of picking a single “best terminal,” design your setup in **four layers**: terminal emulator, shell, workflow tools, and AI layer.
+
+---
+
+## Hook
+For years, many Mac developers used a classic setup: **iTerm2 + Oh My Zsh**.
+
+It still works.
+
+But now we also run AI-assisted workflows in terminal: logs, Git, build/test loops, and agents like Codex / Claude Code / Gemini CLI.
+
+So the question changed from:
+
+> “Which terminal is best?”
+
+to:
+
+> “What command-line workflow fits AI-native development?”
+
+---
+
+## The 4-layer model
+1. **Terminal emulator**: iTerm2 / Ghostty / Warp  
+2. **Shell**: Zsh / Fish / Bash  
+3. **Workflow tools**: tmux / LazyGit / fzf / ripgrep  
+4. **AI layer**: Warp AI / Codex / Claude Code / Gemini CLI
+
+This layering makes your workflow modular and future-proof.
+
+---
+
+## Quick tool breakdown
+### iTerm2
+- Pros: stable, mature, feature-rich
+- Cons: not AI-native
+- Best for: conservative, reliability-first setups
+
+### Oh My Zsh
+- Pros: fast onboarding, huge ecosystem
+- Cons: easy to over-configure and slow startup
+- Tip: keep only high-value plugins
+
+### Fish
+- Pros: great defaults (autosuggest, highlighting, completion)
+- Cons: not fully POSIX-compatible
+- Tip: Fish for interaction, Bash/Zsh for scripts
+
+### Ghostty
+- Pros: lightweight, fast, native feel
+- Cons: AI is not the built-in focus
+- Best for: clean and controllable workflows
+
+### Warp
+- Pros: AI-native UX, command generation, error explanation
+- Cons: heavier, more opinionated product workflow
+- Best for: people who want terminal-as-AI-workbench
+
+### tmux
+- Pros: excellent for remote/dev-server sessions
+- Cons: steeper learning curve
+- Rule of thumb: optional locally, essential remotely
+
+### LazyGit
+- Pros: huge speed boost for frequent Git tasks
+- Note: complements Git knowledge; does not replace it
+
+---
+
+## 3 recommended setups
+### 1) Stable setup
+**iTerm2 + Oh My Zsh + LazyGit**
+
+### 2) Lightweight setup
+**Ghostty + Fish + LazyGit**
+
+### 3) AI-native setup
+**Warp + AI Agent + LazyGit**
+
+---
+
+## My practical recommendation
+- Keep iTerm2 if you value stability and don’t want churn.
+- Try Ghostty if you want modern performance with minimal overhead.
+- Try Warp if you want deep AI in terminal.
+- Use Fish if you want better defaults; stay on Zsh if your setup is already solid.
+- Install LazyGit either way.
+- Adopt tmux when remote/long-running sessions become frequent.
+
+---
+
+## Discussion prompt (for DEV comments)
+What’s your current terminal stack in 2026?
+
+- iTerm2 / Ghostty / Warp?
+- Zsh / Fish?
+- Are you using AI *inside* terminal, or mainly in your editor?
+
+---
+
+## Suggested tags
+`terminal` `productivity` `ai` `developer-tools` `workflow`

--- a/content/notes/ai-cli-era/index.zh-cn.md
+++ b/content/notes/ai-cli-era/index.zh-cn.md
@@ -1,0 +1,146 @@
+---
+title: "AI 时代，我们到底应该用什么命令行工具？"
+date: 2026-04-30
+tags:
+  - 命令行
+  - AI
+  - 工具
+---
+
+今天想聊一个程序员每天都会碰到，但很多人又不太重视的东西：命令行工具。
+
+以前我们在 Mac 上写代码，最常见搭配是 **iTerm2 + Oh My Zsh**。这套组合过去很好用，但在 AI 时代，命令行已经从“输入命令的地方”变成了“开发入口”。
+
+你在里面跑项目、看日志、调 Git、启动 AI Agent、调用 Codex / Claude Code / Gemini CLI，甚至直接让 AI 帮你改代码。
+
+所以问题变成：**AI 时代，我们到底应该用什么命令行工具？**
+
+我的答案是：不要只选“一个终端”，而要按层设计工作流。
+
+- 第 1 层：终端模拟器（iTerm2、Ghostty、Warp）
+- 第 2 层：Shell（Zsh、Fish、Bash）
+- 第 3 层：工作流工具（tmux、LazyGit、fzf、ripgrep）
+- 第 4 层：AI 能力（Warp AI、Claude Code、Codex、Gemini CLI）
+
+---
+
+## 1. iTerm2：经典稳定，但 AI 感不强
+
+iTerm2 依然是 macOS 上非常稳的选择：成熟、稳定、功能全，分屏、标签、快捷键、Profile 都很完善。官方文档也提到，iTerm2 支持把一个标签分成多个 Pane，每个 Pane 都是独立 Session。([iTerm2][2])
+
+短板同样明显：它是传统终端思路，适合“人操作命令行”，不是为“AI 协助开发”原生设计。
+
+结论：**保守型用户继续用 iTerm2 完全没问题。**
+
+---
+
+## 2. Oh My Zsh：好用，但别过度配置
+
+Oh My Zsh 是开源、社区驱动的 Zsh 配置框架，插件和主题非常多。([Oh My Zsh!][3])
+
+优点是上手快；缺点是容易“越配越重”，最后启动变慢、问题难排查。
+
+结论：**可以用，但只留高价值插件。**
+
+---
+
+## 3. Fish：默认体验友好
+
+Fish 的优势是开箱即用：语法高亮、自动建议、补全都默认提供。([Fish Shell][4])
+
+而且它会在输入时给出实时反馈，比如命令不存在、重定向错误等。([Fish Shell][5])
+
+缺点是并非完全 POSIX 兼容，部分 Bash/Zsh 脚本不能直接运行。
+
+结论：**日常交互用 Fish 很舒服；脚本仍建议 Bash/Zsh。**
+
+---
+
+## 4. Ghostty：轻量高性能终端
+
+Ghostty 官方定位是快速、功能丰富、跨平台终端，强调原生 UI 与 GPU 渲染。([Ghostty][6])
+
+它的气质是：快、轻、干净、不绑工作流。你可以自由搭配 Fish/Zsh/tmux/Neovim/各类 AI CLI。
+
+短板是 AI 不是内置重点。
+
+结论：**适合把终端当“高性能容器”的用户。**
+
+---
+
+## 5. Warp：AI 原生终端代表
+
+Warp 目前强调 agentic development，既可用内置 Agent，也能接入 Claude Code、Codex、Gemini CLI。([Warp][7])
+
+另外 Warp 客户端已经开源。([Warp][8])
+
+优势：AI 友好、现代交互、对新手门槛低。
+
+代价：更重、更产品化、工作流“有观点”。而且 AI 生成命令必须审慎执行。
+
+结论：**想把终端变成 AI 工作台，Warp 值得试。**
+
+---
+
+## 6. tmux：老派但仍然强
+
+tmux 的核心是终端复用：多窗口、多面板、detach/reattach，特别适合远程服务器和长任务。([GitHub][9])
+
+本地 GUI 终端分屏已经很够用时，不一定必须上 tmux；但远程开发场景它依然非常硬核。
+
+---
+
+## 7. LazyGit：Git 效率神器
+
+LazyGit 是 Git 的终端 UI。([GitHub][10])
+
+它特别适合高频 diff/stage/commit、分支管理、stash/rebase/cherry-pick。不是替你理解 Git，而是让懂 Git 的人更快。
+
+---
+
+## 8. 三套推荐组合
+
+### 稳定保守型
+**iTerm2 + Oh My Zsh + LazyGit**
+
+### 轻量高效型
+**Ghostty + Fish + LazyGit**
+
+### AI 原生型
+**Warp + AI Agent + LazyGit**
+
+---
+
+## 9. 我的最终建议
+
+- 普通开发者继续用 iTerm2 没问题。
+- 想要更现代、更轻量，试 Ghostty。
+- 想要 AI 深度集成，试 Warp。
+- Shell：不想折腾用 Fish，已习惯 Zsh 就继续用。
+- Git：LazyGit 非常值得装。
+- tmux：有远程开发/长期 Session 需求再上。
+
+我自己的倾向是：
+
+> Ghostty 做主力终端，Fish 做日常 Shell，LazyGit 处理 Git，AI 编程交给 Codex / Claude Code / Gemini CLI。需要 AI 终端体验时，再打开 Warp。
+
+---
+
+## 结尾
+
+AI 时代，命令行不会消失，反而会更重要。
+
+过去命令行是“程序员和机器”的接口；未来它更像“程序员、AI Agent、机器”的共同工作台。
+
+所以我们选择命令行工具，不是在选一个黑窗口，而是在选自己的开发方式。
+
+[1]: https://iterm2.com/features.html?utm_source=chatgpt.com "Features - iTerm2 - macOS Terminal Replacement"
+[2]: https://iterm2.com/documentation/2.1/documentation-one-page.html?utm_source=chatgpt.com "Documentation - iTerm2 - Mac OS Terminal Replacement"
+[3]: https://ohmyz.sh/?utm_source=chatgpt.com "Oh My Zsh - a delightful & open source framework for Zsh"
+[4]: https://fishshell.com/docs/current/tutorial.html?utm_source=chatgpt.com "Tutorial — fish-shell documentation"
+[5]: https://fishshell.com/docs/current/interactive.html?utm_source=chatgpt.com "Interactive use — fish-shell documentation"
+[6]: https://ghostty.org/?utm_source=chatgpt.com "Ghostty"
+[7]: https://www.warp.dev/?utm_source=chatgpt.com "Warp Terminal"
+[8]: https://www.warp.dev/blog/warp-is-now-open-source?utm_source=chatgpt.com "Warp is now open-source"
+[9]: https://github.com/tmux/tmux/wiki?utm_source=chatgpt.com "Home · tmux/tmux Wiki"
+[10]: https://github.com/jesseduffield/lazygit?utm_source=chatgpt.com "jesseduffield/lazygit: simple terminal UI for git commands"


### PR DESCRIPTION
### Motivation
- Provide ready-to-publish distribution templates for the "AI 时代，我们到底应该用什么命令行工具？" article across multiple platforms. 
- Offer both Chinese and English variants to streamline cross-platform publishing workflows. 
- Add a canonical Chinese article page with front matter to include the note in the site content tree.

### Description
- Added `content/notes/ai-cli-era/distribution/csdn-template.zh-cn.md` which is a CSDN-ready Chinese publishing template for the article. 
- Added `content/notes/ai-cli-era/distribution/devto-template.en.md` which is an English DEV.to publishing template summarizing the 4-layer CLI model and recommended stacks. 
- Added `content/notes/ai-cli-era/index.zh-cn.md` as the primary Chinese article page with front matter, full content, references, tags, and recommended configurations.

### Testing
- No automated tests were run for these content-only changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2adff0f30832daa19b019c0b1c333)