### PR TITLE
fix: restore nav links for pillar pages

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -49,6 +49,7 @@ buildFuture = true
     startLevel = 2
 
 [languages.en.permalinks]
+pages = "/:slugorcontentbasename/"
 posts = "/:slugorcontentbasename/"
 notes = "/:slugorcontentbasename/"
 book-reports = "/:slugorcontentbasename/"
@@ -63,6 +64,7 @@ gallery = "/:slugorcontentbasename/"
 raw = "/:slugorcontentbasename/"
 
 [languages.zh-CN.permalinks]
+pages = "/:slugorcontentbasename/"
 posts = "/:slugorcontentbasename/"
 notes = "/:slugorcontentbasename/"
 book-reports = "/:slugorcontentbasename/"


### PR DESCRIPTION
### Motivation
- Navigation menu items pointed to top-level slugs but pages under `content/pages/*` were being published under `/pages/<slug>/`, causing 404s from the menu.

### Description
- Add `pages = "/:slugorcontentbasename/"` to both `[languages.en.permalinks]` and `[languages.zh-CN.permalinks]` in `config.toml` so section pages are published at top-level routes like `/ai-indie-hacking/`, `/ai-coding-workflow/`, and `/creator-workflow/`.

### Testing
- Attempted to build with `hugo --minify` but it failed because `hugo` is not installed in the environment (`command not found`).
- Ran `npm run check-format` which failed due to a missing local Prettier plugin `prettier-plugin-go-template`, which is an environment dependency and not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12ae151240832d88b8d6ef5978c6d9)