### PR TITLE
Fix dark-mode white flash when navigating links

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -4,7 +4,24 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="google-adsense-account" content="ca-pub-6892599483138014">
-    <meta name="theme-color" content="#FFFFFF" />
+    <meta name="theme-color" media="(prefers-color-scheme: light)" content="#ffffff" />
+    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#212121" />
+    <script>
+      (function () {
+        var preferred = 'light';
+        try {
+          var saved = localStorage.getItem('colorscheme');
+          if (saved === 'dark' || saved === 'light') {
+            preferred = saved;
+          } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+            preferred = 'dark';
+          }
+        } catch (e) {}
+        if (preferred === 'dark') {
+          document.documentElement.style.backgroundColor = '#212121';
+        }
+      })();
+    </script>
     <link rel="manifest" href="/manifest.json" />
     <meta name="baidu-site-verification" content="codeva-UenLF4MOmu" />
     <link rel="apple-touch-icon" href="/images/avatar.avif" />


### PR DESCRIPTION
### Motivation
- Prevent a brief white flash on page navigation in dark mode that occurs while CSS and theme styles are still loading.
- Ensure the browser uses the correct theme color and initial background as early as possible to avoid visible flash between pages.

### Description
- Replace the single static `theme-color` meta tag with media-aware tags: `media="(prefers-color-scheme: light)"` and `media="(prefers-color-scheme: dark)"` to provide correct toolbar color for each mode.
- Add a small inline script in the `<head>` that reads `localStorage.getItem('colorscheme')` or falls back to `matchMedia('(prefers-color-scheme: dark)')` and sets `document.documentElement.style.backgroundColor = '#212121'` when dark mode is active so the initial background is correct before CSS loads.
- Change applied to `layouts/_default/baseof.html` so the bootstrap runs as early as possible in page load.

### Testing
- Attempted to run `hugo version && rm -rf public && hugo --minify` to build the site, but the command failed in this environment with `hugo: command not found` so a production build could not be verified here.
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14642460a0832dbf827987a7e7e1b1)