### PR TITLE
Improve homepage positioning and structure

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -2,16 +2,112 @@
 other = "Felix Mao"
 
 [homeBio]
-other = "Hey! I'm Felix Mao, a senior Frontend Engineer with 10+ years at big tech companies. A reading enthusiast, crypto and index investor."
+other = "Build with AI. Think in systems. Compound for the long run."
 
 [homePara1]
-other = """I write <a href="/posts/">blog posts</a> and <a href="/notes/">notes</a> about frontend development, AI applications, and investment strategies. I also share <a href="/book-reports/">book reports</a> on what I've been reading. You can find my <a href="/projects/">full projects list here</a>."""
+other = """I'm Felix Mao, a frontend engineer and creator writing about AI coding, indie hacking, creator workflows, personal knowledge systems, and long-term investing."""
 
 [homePara2]
-other = """Currently focused on LEARN, BUILD and GROW with AGI. Exploring two areas: Tech (AI &amp; Frontend Innovation) and Investment (BTC, VGT &amp; VOO). Weekly updates with fresh perspectives on tech and investment."""
+other = """This site is my public notebook for turning code, media, and capital into personal leverage: I test AI tools, build small products, document workflows, and translate investing ideas into simple systems."""
 
 [homePara3]
-other = """Outside of coding, I enjoy reading, drawing, and content creation. Check out my <a href="/gallery/">visual gallery</a>, the <a href="/uses/">hardware/software I use</a>, my <a href="/bookmarks/">curated bookmarks</a>, and my <a href="/media/">media consumption</a>."""
+other = """Start with the guides below, browse the latest writing, or follow my work on Substack, Twitter/X, YouTube and GitHub."""
+
+[homeCtaPrimary]
+other = "Start Here"
+
+[homeCtaSecondary]
+other = "Subscribe"
+
+[homeFocusTitle]
+other = "What I Write About"
+
+[homeFocusIntro]
+other = "Four connected themes: AI for leverage, code for products, media for distribution, and investing for long-term compounding."
+
+[homeTopic1Title]
+other = "AI Coding"
+
+[homeTopic1Desc]
+other = "Real workflows with Cursor, Claude Code, Codex, Gemini CLI, Vercel and frontend engineering."
+
+[homeTopic2Title]
+other = "AI Indie Hacking"
+
+[homeTopic2Desc]
+other = "How solo builders find problems, ship AI products, price them, and build distribution loops."
+
+[homeTopic3Title]
+other = "Creator Workflows"
+
+[homeTopic3Desc]
+other = "Turning raw ideas into articles, newsletters, videos, visuals, and reusable publishing systems."
+
+[homeTopic4Title]
+other = "Long-term Investing"
+
+[homeTopic4Desc]
+other = "Index funds, technology ETFs, Bitcoin, cash flow, risk control, and practical asset allocation."
+
+[homeStartHereTitle]
+other = "Start Here"
+
+[homeStartHereIntro]
+other = "New here? These essays are the best entry points into the site."
+
+[homeStart1Title]
+other = "AI Coding Playbook"
+
+[homeStart1Desc]
+other = "Tool selection, workflows, and prompt templates for building with AI."
+
+[homeStart2Title]
+other = "AI Agent Beginner's Guide"
+
+[homeStart2Desc]
+other = "Understand agents, protocols, and where the real leverage is."
+
+[homeStart3Title]
+other = "Karpathy's Personal Knowledge Base Method"
+
+[homeStart3Desc]
+other = "Use a Git repository as a living knowledge base."
+
+[homeStart4Title]
+other = "How to Build Real Wealth"
+
+[homeStart4Desc]
+other = "A practical lens on money, compounding, and long-term systems."
+
+[homeProofTitle]
+other = "Projects & Publications"
+
+[homeProofIntro]
+other = "A few things I've shipped or published."
+
+[homeProof1Title]
+other = "Options Made Simple"
+
+[homeProof1Desc]
+other = "A beginner-friendly guide to options trading."
+
+[homeProof2Title]
+other = "Twitter Crawler"
+
+[homeProof2Desc]
+other = "A Chrome extension for collecting and extracting high-quality X/Twitter content."
+
+[homeProof3Title]
+other = "maoxunxing.com"
+
+[homeProof3Desc]
+other = "My public knowledge node built with Hugo."
+
+[homeProof4Title]
+other = "Modern JavaScript Translation"
+
+[homeProof4Desc]
+other = "Chinese translation of Modern JavaScript for the Impatient."
 
 [homeFindMe]
 other = "Find me on"

--- a/i18n/zh-cn.toml
+++ b/i18n/zh-cn.toml
@@ -2,16 +2,112 @@
 other = "毛毛星"
 
 [homeBio]
-other = "Hi，我是毛毛星，一名资深前端工程师，互联网大厂从业 10 年+。前网易、阿里员工。热爱阅读，加密货币和指数基金投资者。"
+other = "用 AI 构建，用系统思考，用长期主义复利。"
 
 [homePara1]
-other = """我写<a href="/zh-cn/posts/">技术博客</a>和<a href="/zh-cn/notes/">随笔</a>，分享前端开发、AI 应用和投资策略方面的思考。也会分享<a href="/zh-cn/book-reports/">读书报告</a>。你可以在<a href="/zh-cn/projects/">项目页面</a>查看我的全部项目。"""
+other = """Hi，我是毛毛星。前端工程师，也是一个正在公开构建的创作者。我主要记录 AI Coding、独立产品、创作者工作流、个人知识系统和长期投资。"""
 
 [homePara2]
-other = """目前专注于 Learn、Build and Grow with AGI。探索两个方向：技术（AI 与前端创新实践）和投资（BTC、VGT、VOO 的投资复盘）。每周更新，用简单的视角解读技术与投资。"""
+other = """这个网站是我的公开知识节点：我会测试 AI 工具，做小产品，整理内容生产流程，也会把投资思考翻译成更简单、可执行的系统。"""
 
 [homePara3]
-other = """编程之外，我喜欢阅读、绘画和内容创作。可以看看我的<a href="/zh-cn/gallery/">画廊</a>、我使用的<a href="/zh-cn/uses/">软硬件装备</a>、我整理的<a href="/zh-cn/bookmarks/">书签收藏</a>，以及我的<a href="/zh-cn/media/">影音记录</a>。"""
+other = """你可以从下面的 Start Here 开始，也可以直接看最新文章，或者在 Substack、Twitter/X、YouTube 和 GitHub 上关注我的持续更新。"""
+
+[homeCtaPrimary]
+other = "从这里开始"
+
+[homeCtaSecondary]
+other = "订阅更新"
+
+[homeFocusTitle]
+other = "我主要写什么"
+
+[homeFocusIntro]
+other = "四条主线：AI 提升杠杆，代码构建产品，媒体放大分发，投资追求长期复利。"
+
+[homeTopic1Title]
+other = "AI Coding"
+
+[homeTopic1Desc]
+other = "Cursor、Claude Code、Codex、Gemini CLI、Vercel 与前端工程中的真实工作流。"
+
+[homeTopic2Title]
+other = "AI 独立产品"
+
+[homeTopic2Desc]
+other = "一个人如何发现问题、构建 AI 产品、设计定价，并建立分发闭环。"
+
+[homeTopic3Title]
+other = "创作者工作流"
+
+[homeTopic3Desc]
+other = "把零散想法变成文章、Newsletter、视频、视觉图和可复用的发布系统。"
+
+[homeTopic4Title]
+other = "长期投资"
+
+[homeTopic4Desc]
+other = "指数基金、科技 ETF、比特币、现金流、风险控制和普通人可执行的资产配置。"
+
+[homeStartHereTitle]
+other = "Start Here"
+
+[homeStartHereIntro]
+other = "第一次来这里，可以先从这几篇代表性内容开始。"
+
+[homeStart1Title]
+other = "AI Coding Playbook"
+
+[homeStart1Desc]
+other = "AI 编程工具选择、工作流和提示词模板。"
+
+[homeStart2Title]
+other = "AI Agent 入门指南"
+
+[homeStart2Desc]
+other = "理解 Agent、协议与真正的效率杠杆。"
+
+[homeStart3Title]
+other = "Karpathy 的个人知识库方法"
+
+[homeStart3Desc]
+other = "用 Git 仓库搭建一个长期演化的个人知识库。"
+
+[homeStart4Title]
+other = "如何构建真正的财富"
+
+[homeStart4Desc]
+other = "关于金钱、复利和长期系统的一种实践视角。"
+
+[homeProofTitle]
+other = "项目与作品"
+
+[homeProofIntro]
+other = "一些我已经发布或正在构建的东西。"
+
+[homeProof1Title]
+other = "Options Made Simple"
+
+[homeProof1Desc]
+other = "一本写给期权新手的入门书。"
+
+[homeProof2Title]
+other = "Twitter Crawler"
+
+[homeProof2Desc]
+other = "一个用于收集和提取高质量 X/Twitter 内容的 Chrome 插件。"
+
+[homeProof3Title]
+other = "maoxunxing.com"
+
+[homeProof3Desc]
+other = "用 Hugo 搭建的个人公开知识节点。"
+
+[homeProof4Title]
+other = "Modern JavaScript 翻译"
+
+[homeProof4Desc]
+other = "《Modern JavaScript for the Impatient》的中文翻译。"
 
 [homeFindMe]
 other = "在这里找到我"

--- a/layouts/partials/home.html
+++ b/layouts/partials/home.html
@@ -44,7 +44,98 @@
 
   <p class="home-para">{{ i18n "homePara3" | safeHTML }}</p>
 
+  <p class="home-cta-row">
+    <a class="home-cta home-cta-primary" href="#start-here">{{ i18n "homeCtaPrimary" | default "Start Here" }}</a>
+    <a class="home-cta" href="https://maoxunxing.substack.com/" target="_blank" rel="noopener">{{ i18n "homeCtaSecondary" | default "Subscribe" }}</a>
+  </p>
+
   <div class="home-spacer"></div>
+
+  <hr class="home-divider" />
+
+  <section class="home-block" aria-labelledby="home-focus-title">
+    <h2 id="home-focus-title" class="home-section-title">{{ i18n "homeFocusTitle" | default "What I Write About" }}</h2>
+    <p class="home-muted">{{ i18n "homeFocusIntro" | safeHTML }}</p>
+
+    <div class="home-card-grid">
+      <a class="home-card" href="{{ "ai-coding-workflow/" | relLangURL }}">
+        <span class="home-card-kicker">01</span>
+        <span class="home-card-title">{{ i18n "homeTopic1Title" }}</span>
+        <span class="home-card-desc">{{ i18n "homeTopic1Desc" }}</span>
+      </a>
+      <a class="home-card" href="{{ "ai-indie-hacking/" | relLangURL }}">
+        <span class="home-card-kicker">02</span>
+        <span class="home-card-title">{{ i18n "homeTopic2Title" }}</span>
+        <span class="home-card-desc">{{ i18n "homeTopic2Desc" }}</span>
+      </a>
+      <a class="home-card" href="{{ "creator-workflow/" | relLangURL }}">
+        <span class="home-card-kicker">03</span>
+        <span class="home-card-title">{{ i18n "homeTopic3Title" }}</span>
+        <span class="home-card-desc">{{ i18n "homeTopic3Desc" }}</span>
+      </a>
+      <a class="home-card" href="{{ "posts/invest/" | relLangURL }}">
+        <span class="home-card-kicker">04</span>
+        <span class="home-card-title">{{ i18n "homeTopic4Title" }}</span>
+        <span class="home-card-desc">{{ i18n "homeTopic4Desc" }}</span>
+      </a>
+    </div>
+  </section>
+
+  <hr class="home-divider" />
+
+  <section id="start-here" class="home-block" aria-labelledby="start-here-title">
+    <h2 id="start-here-title" class="home-section-title">{{ i18n "homeStartHereTitle" | default "Start Here" }}</h2>
+    <p class="home-muted">{{ i18n "homeStartHereIntro" | safeHTML }}</p>
+
+    <ul class="article-list home-featured-list">
+      <li class="article-item">
+        <span class="article-section-tag">AI</span>
+        <a class="article-title" href="{{ "ai-coding-workflow/" | relLangURL }}">{{ i18n "homeStart1Title" }}</a>
+        <span class="home-featured-desc">{{ i18n "homeStart1Desc" }}</span>
+      </li>
+      <li class="article-item">
+        <span class="article-section-tag">Agent</span>
+        <a class="article-title" href="{{ "ai-indie-hacking/" | relLangURL }}">{{ i18n "homeStart2Title" }}</a>
+        <span class="home-featured-desc">{{ i18n "homeStart2Desc" }}</span>
+      </li>
+      <li class="article-item">
+        <span class="article-section-tag">PKM</span>
+        <a class="article-title" href="{{ "posts/karpathy-knowledge-base-practice/" | relLangURL }}">{{ i18n "homeStart3Title" }}</a>
+        <span class="home-featured-desc">{{ i18n "homeStart3Desc" }}</span>
+      </li>
+      <li class="article-item">
+        <span class="article-section-tag">Investing</span>
+        <a class="article-title" href="{{ "posts/invest/" | relLangURL }}">{{ i18n "homeStart4Title" }}</a>
+        <span class="home-featured-desc">{{ i18n "homeStart4Desc" }}</span>
+      </li>
+    </ul>
+  </section>
+
+  <hr class="home-divider" />
+
+  <section class="home-block" aria-labelledby="home-proof-title">
+    <h2 id="home-proof-title" class="home-section-title">{{ i18n "homeProofTitle" | default "Projects & Publications" }}</h2>
+    <p class="home-muted">{{ i18n "homeProofIntro" | safeHTML }}</p>
+
+    <div class="home-card-grid home-proof-grid">
+      <a class="home-card" href="https://leanpub.com/optionsmadesimple" target="_blank" rel="noopener">
+        <span class="home-card-title">{{ i18n "homeProof1Title" }}</span>
+        <span class="home-card-desc">{{ i18n "homeProof1Desc" }}</span>
+      </a>
+      <a class="home-card" href="{{ "projects/" | relLangURL }}">
+        <span class="home-card-title">{{ i18n "homeProof2Title" }}</span>
+        <span class="home-card-desc">{{ i18n "homeProof2Desc" }}</span>
+      </a>
+      <a class="home-card" href="https://github.com/XingMXTeam/maoxunxing.com" target="_blank" rel="noopener">
+        <span class="home-card-title">{{ i18n "homeProof3Title" }}</span>
+        <span class="home-card-desc">{{ i18n "homeProof3Desc" }}</span>
+      </a>
+      <a class="home-card" href="{{ "projects/" | relLangURL }}">
+        <span class="home-card-title">{{ i18n "homeProof4Title" }}</span>
+        <span class="home-card-desc">{{ i18n "homeProof4Desc" }}</span>
+      </a>
+    </div>
+  </section>
 
   <hr class="home-divider" />
 


### PR DESCRIPTION
## Summary

- Reposition the homepage around AI coding, indie hacking, creator workflows, and long-term investing
- Add clearer hero copy and CTA links
- Add What I Write About, Start Here, and Projects & Publications sections
- Keep the latest writing feed and existing social links
- Update both English and Chinese homepage i18n copy

## Notes

This PR focuses on homepage content architecture and conversion flow. Visual styling can be further refined after previewing the deployed page.