### PR TITLE
Fix SEO template issues for missing H1 and image alt text

### DIFF
--- a/layouts/partials/book-reports/page.html
+++ b/layouts/partials/book-reports/page.html
@@ -9,7 +9,7 @@
     <a href="{{ .Params.purchase_url }}">
       {{- $cover := .Resources.GetMatch "cover.*" -}}
       {{- with $cover -}}
-        <img src="{{ .RelPermalink }}" class="align-left book-cover" />
+        <img src="{{ .RelPermalink }}" alt="{{ $.Title }} cover" class="align-left book-cover" />
       {{- end -}}
     </a>
 

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -8,7 +8,7 @@
         <header>
           {{ if .Page.Params.hero_image }}
             <a href="{{ .Page.Params.hero_image }}">
-              <img src="{{ .Page.Params.hero_image }}" />
+              <img src="{{ .Page.Params.hero_image }}" alt="{{ .Title }} hero image" />
             </a>
           {{ end }}
           <div class="post-title">

--- a/layouts/projects/list.html
+++ b/layouts/projects/list.html
@@ -3,6 +3,7 @@
 {{ end }}
 {{ define "content" }}
 <section class="container projects-page">
+  <h1 class="title">{{ .Title }}</h1>
   {{ range $category, $items := .Params.projects }}
   <div class="project-category">
     <div class="project-category-bg">{{ $category }}</div>


### PR DESCRIPTION
### Motivation
- Ensure pages render a clear primary heading for SEO/accessibility scanners and avoid automated SEO failures for missing `<h1>` tags.
- Provide meaningful `alt` attributes for hero and cover images to satisfy accessibility and image-alt checks.

### Description
- Added an explicit page-level `<h1>` to the projects list template in `layouts/projects/list.html` so the projects page has a primary heading.
- Added `alt` text for the post hero image in `layouts/posts/single.html` to give a descriptive fallback for screen readers.
- Added `alt` text for book report cover images in `layouts/partials/book-reports/page.html` to cover generated book pages.

### Testing
- Ran `rg --pcre2 -n "<img(?![^>]*alt=)" layouts` which returned only the shortcode `layouts/shortcodes/img.html`, indicating the explicit templates now include `alt` text (success).
- Ran `hugo version` which failed in this environment because `hugo` is not installed in PATH (environment failure, not related to templates).
- Ran `npm run check-format` which failed due to a missing `prettier-plugin-go-template` referenced by the repo config (environment/config issue, not caused by these changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1706b9be70832d9b62a6b170b8c007)