### PR TITLE
Add Antfu-inspired photo gallery

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
+          lfs: true
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -12,6 +12,7 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
+          lfs: true
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:

--- a/config.toml
+++ b/config.toml
@@ -163,13 +163,9 @@ resampleFilter = "Lanczos"
   pageRef = "/projects"
   weight = 6
 [[languages.en.menu.main]]
-  name = "Photos"
-  pageRef = "/gallery"
-  weight = 7
-[[languages.en.menu.main]]
   name = "About"
   pageRef = "/about"
-  weight = 8
+  weight = 7
 [[languages.zh-CN.menu.main]]
   name = "博客"
   pageRef = "/posts"
@@ -195,10 +191,6 @@ resampleFilter = "Lanczos"
   pageRef = "/projects"
   weight = 6
 [[languages.zh-CN.menu.main]]
-  name = "照片"
-  pageRef = "/gallery"
-  weight = 7
-[[languages.zh-CN.menu.main]]
   name = "关于"
   pageRef = "/about"
-  weight = 8
+  weight = 7

--- a/config.toml
+++ b/config.toml
@@ -163,9 +163,13 @@ resampleFilter = "Lanczos"
   pageRef = "/projects"
   weight = 6
 [[languages.en.menu.main]]
+  name = "Photos"
+  pageRef = "/gallery"
+  weight = 7
+[[languages.en.menu.main]]
   name = "About"
   pageRef = "/about"
-  weight = 7
+  weight = 8
 [[languages.zh-CN.menu.main]]
   name = "博客"
   pageRef = "/posts"
@@ -191,6 +195,10 @@ resampleFilter = "Lanczos"
   pageRef = "/projects"
   weight = 6
 [[languages.zh-CN.menu.main]]
+  name = "照片"
+  pageRef = "/gallery"
+  weight = 7
+[[languages.zh-CN.menu.main]]
   name = "关于"
   pageRef = "/about"
-  weight = 7
+  weight = 8

--- a/content/gallery/_index.md
+++ b/content/gallery/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Gallery"
+title: "Photos"
 layout: gallery
-description: "Diagrams, sketches, and visual works"
+description: "Photos from life, travels, and the moments I wanted to keep"
 ---

--- a/content/gallery/_index.zh-cn.md
+++ b/content/gallery/_index.zh-cn.md
@@ -1,5 +1,5 @@
 ---
-title: "画廊"
+title: "照片"
 layout: gallery
-description: "图表、草图和视觉作品"
+description: "生活、旅途与那些想留下来的瞬间"
 ---

--- a/layouts/page/gallery.html
+++ b/layouts/page/gallery.html
@@ -1,21 +1,132 @@
 {{ define "title" }}
   {{ .Title }} · {{ .Site.Title }}
 {{ end }}
-{{ define "content" }}
-<section class="container">
-  <h1 class="title">{{ .Title }}</h1>
 
-  {{ $images := .Resources.ByType "image" }}
+{{ define "content" }}
+{{ $images := slice }}
+{{ range resources.Match "photos/**" }}
+  {{ if eq .MediaType.MainType "image" }}
+    {{ $images = $images | append . }}
+  {{ end }}
+{{ end }}
+{{ $images = sort $images "Name" "desc" }}
+{{ $isZh := eq .Site.Language.Lang "zh-CN" }}
+
+<link rel="stylesheet" href="/css/gallery.css?v=20260711a" />
+
+<section class="photo-gallery-page" data-photo-gallery data-view="cover">
+  <header class="photo-gallery-header">
+    <div class="photo-gallery-heading">
+      <h1 class="title">{{ .Title }}</h1>
+      {{ with .Description }}
+      <p class="photo-gallery-description">{{ . }}</p>
+      {{ end }}
+    </div>
+
+    {{ if gt (len $images) 0 }}
+    <button
+      class="photo-view-toggle"
+      type="button"
+      data-photo-view-toggle
+      data-cover-label="{{ if $isZh }}切换为完整图片视图{{ else }}Switch to full-image view{{ end }}"
+      data-contain-label="{{ if $isZh }}切换为裁切网格视图{{ else }}Switch to cropped grid view{{ end }}"
+      aria-label="{{ if $isZh }}切换为完整图片视图{{ else }}Switch to full-image view{{ end }}"
+      aria-pressed="false"
+      title="{{ if $isZh }}切换图片布局{{ else }}Switch photo layout{{ end }}"
+    >
+      <svg class="photo-view-icon photo-view-icon-cover" viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M4 4h6v6H4zM14 4h6v6h-6zM4 14h6v6H4zM14 14h6v6h-6z" />
+      </svg>
+      <svg class="photo-view-icon photo-view-icon-contain" viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M4 5h16v14H4zM7 16l3.5-4 2.5 3 2-2 2 3H7zM16.5 8.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z" />
+      </svg>
+    </button>
+    {{ end }}
+  </header>
+
   {{ if gt (len $images) 0 }}
-  <div class="gallery-grid">
-    {{ range $images }}
-    <a class="gallery-item" href="{{ .RelPermalink }}">
-      <img src="{{ .RelPermalink }}" alt="{{ .Title }}" loading="lazy" />
+  <div
+    class="photo-grid photos"
+    role="list"
+    aria-label="{{ if $isZh }}照片集{{ else }}Photo gallery{{ end }}"
+  >
+    {{ range $index, $image := $images }}
+      {{ $baseName := path.BaseName $image.Name }}
+      {{ $alt := humanize (replaceRE `[-_]+` " " $baseName) }}
+      {{ $thumb := $image.Fit "900x900 webp q82" }}
+    <a
+      class="photo-item"
+      href="{{ $image.RelPermalink }}"
+      role="listitem"
+      data-photo-index="{{ $index }}"
+      data-photo-alt="{{ $alt }}"
+      aria-label="{{ if $isZh }}查看照片：{{ $alt }}{{ else }}View photo: {{ $alt }}{{ end }}"
+    >
+      <img
+        src="{{ $thumb.RelPermalink }}"
+        alt="{{ $alt }}"
+        loading="lazy"
+        decoding="async"
+        width="{{ $thumb.Width }}"
+        height="{{ $thumb.Height }}"
+      />
     </a>
     {{ end }}
   </div>
+
+  <p class="photo-gallery-note">
+    {{ if $isZh }}共 {{ len $images }} 张照片。谢谢你愿意看看这些被留下来的瞬间。{{ else }}{{ len $images }} photos. Thank you for taking a look at the moments I chose to keep.{{ end }}
+  </p>
+
+  <div
+    class="photo-lightbox"
+    data-photo-lightbox
+    role="dialog"
+    aria-modal="true"
+    aria-label="{{ if $isZh }}照片预览{{ else }}Photo preview{{ end }}"
+    hidden
+  >
+    <button
+      class="photo-lightbox-close"
+      type="button"
+      data-photo-lightbox-close
+      aria-label="{{ if $isZh }}关闭照片预览{{ else }}Close photo preview{{ end }}"
+    >
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m6 6 12 12M18 6 6 18" /></svg>
+    </button>
+
+    <button
+      class="photo-lightbox-nav photo-lightbox-prev"
+      type="button"
+      data-photo-lightbox-prev
+      aria-label="{{ if $isZh }}上一张照片{{ else }}Previous photo{{ end }}"
+    >
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m15 5-7 7 7 7" /></svg>
+    </button>
+
+    <figure class="photo-lightbox-figure">
+      <img data-photo-lightbox-image src="" alt="" />
+      <figcaption class="photo-lightbox-meta">
+        <span data-photo-lightbox-caption></span>
+        <span data-photo-lightbox-count></span>
+      </figcaption>
+    </figure>
+
+    <button
+      class="photo-lightbox-nav photo-lightbox-next"
+      type="button"
+      data-photo-lightbox-next
+      aria-label="{{ if $isZh }}下一张照片{{ else }}Next photo{{ end }}"
+    >
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m9 5 7 7-7 7" /></svg>
+    </button>
+  </div>
   {{ else }}
-  <p style="opacity:0.5">No images yet. Add images to the gallery folder to display them here.</p>
+  <p class="photo-gallery-empty">
+    {{ if $isZh }}还没有照片。把图片放进 <code>assets/photos</code> 后，它们会自动出现在这里。{{ else }}No photos yet. Add images to <code>assets/photos</code> and they will appear here automatically.{{ end }}
+  </p>
   {{ end }}
 </section>
+
+<script defer src="/js/gallery.js?v=20260711a"></script>
 {{ end }}

--- a/layouts/page/gallery.html
+++ b/layouts/page/gallery.html
@@ -4,8 +4,9 @@
 
 {{ define "content" }}
 {{ $images := slice }}
+{{ $supportedExtensions := slice ".jpg" ".jpeg" ".png" ".webp" ".gif" ".avif" }}
 {{ range resources.Match "photos/**" }}
-  {{ if eq .MediaType.MainType "image" }}
+  {{ if in $supportedExtensions (lower (path.Ext .Name)) }}
     {{ $images = $images | append . }}
   {{ end }}
 {{ end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,3 +1,5 @@
+{{- $galleryURL := "/gallery/" | relLangURL -}}
+{{- $isZh := eq .Site.Language.Lang "zh-CN" -}}
 <nav class="navigation" aria-label="Main navigation">
   <section class="nav-container">
     <!-- Animated M signature logo -->
@@ -42,6 +44,31 @@
         <span class="mobile-menu-section-label sr-only">Tools</span>
         <div class="nav-utility-row">
           <div class="nav-search-box" id="docsearch"></div>
+
+          <a
+            href="{{ $galleryURL }}"
+            class="nav-icon-link nav-photo-link"
+            title="{{ if $isZh }}照片{{ else }}Photos{{ end }}"
+            aria-label="{{ if $isZh }}查看照片集{{ else }}View photo gallery{{ end }}"
+            {{ if eq .RelPermalink $galleryURL }}aria-current="page"{{ end }}
+          >
+            <svg
+              class="nav-camera-icon"
+              width="1.2em"
+              height="1.2em"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.8"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+              focusable="false"
+            >
+              <path d="M14.5 4 16 6h3a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h3l1.5-2h5z"></path>
+              <circle cx="12" cy="13" r="3.25"></circle>
+            </svg>
+          </a>
 
           <button
             type="button"

--- a/static/css/gallery.css
+++ b/static/css/gallery.css
@@ -1,0 +1,376 @@
+/* Antfu-inspired photo gallery */
+.photo-gallery-page {
+  position: relative;
+  left: 50%;
+  width: min(160rem, calc(100vw - 3.2rem));
+  transform: translateX(-50%);
+}
+
+.photo-gallery-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 2rem;
+  max-width: 65ch;
+  margin: 0 auto 2.4rem;
+}
+
+.photo-gallery-heading {
+  min-width: 0;
+}
+
+.photo-gallery-header .title {
+  margin-bottom: 0.6rem;
+}
+
+.photo-gallery-description {
+  margin: 0;
+  color: var(--c-fg-light);
+}
+
+.photo-view-toggle {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  width: 4rem;
+  height: 4rem;
+  padding: 0;
+  border: 0;
+  border-radius: 999px;
+  color: var(--c-fg-light);
+  background: transparent;
+  cursor: pointer;
+  transition: color 160ms ease, background-color 160ms ease, transform 160ms ease;
+}
+
+.photo-view-toggle:hover,
+.photo-view-toggle:focus-visible {
+  color: var(--c-fg-deeper);
+  background: rgba(125, 125, 125, 0.1);
+}
+
+.photo-view-toggle:active {
+  transform: scale(0.94);
+}
+
+.photo-view-toggle:focus-visible,
+.photo-item:focus-visible,
+.photo-lightbox button:focus-visible {
+  outline: 2px solid var(--c-link);
+  outline-offset: 3px;
+}
+
+.photo-view-icon {
+  width: 2rem;
+  height: 2rem;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.7;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.photo-view-icon-cover {
+  fill: currentColor;
+  stroke: none;
+}
+
+.photo-view-icon-contain {
+  display: none;
+}
+
+.photo-gallery-page[data-view="contain"] .photo-view-icon-cover {
+  display: none;
+}
+
+.photo-gallery-page[data-view="contain"] .photo-view-icon-contain {
+  display: block;
+}
+
+.photo-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1.6rem;
+  max-width: 160rem;
+  margin: 0 auto;
+}
+
+.photo-item {
+  position: relative;
+  display: block;
+  aspect-ratio: 1;
+  overflow: hidden;
+  border: 0 !important;
+  border-radius: 0;
+  background: rgba(125, 125, 125, 0.06);
+  cursor: zoom-in;
+  content-visibility: auto;
+  contain-intrinsic-size: 32rem;
+}
+
+.photo-item::after {
+  position: absolute;
+  inset: 0;
+  border: 1px solid transparent;
+  pointer-events: none;
+  content: "";
+  transition: border-color 180ms ease, background-color 180ms ease;
+}
+
+.photo-item:hover::after {
+  border-color: rgba(255, 255, 255, 0.2);
+  background: rgba(0, 0, 0, 0.04);
+}
+
+.photo-item img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transform: scale(1.001);
+  transition: transform 280ms ease, opacity 280ms ease;
+}
+
+.photo-item:hover img {
+  transform: scale(1.025);
+}
+
+.photo-gallery-page[data-view="contain"] .photo-item {
+  background: rgba(125, 125, 125, 0.075);
+}
+
+.photo-gallery-page[data-view="contain"] .photo-item img {
+  object-fit: contain;
+  padding: 0.8rem;
+  transform: none;
+}
+
+.photo-gallery-page[data-view="contain"] .photo-item:hover img {
+  opacity: 0.88;
+}
+
+.photo-gallery-note,
+.photo-gallery-empty {
+  max-width: 65ch;
+  margin: 3.2rem auto 0;
+  color: var(--c-fg-light);
+  font-size: 1.35rem;
+  font-style: italic;
+}
+
+.photo-lightbox[hidden] {
+  display: none;
+}
+
+.photo-lightbox {
+  position: fixed;
+  inset: 0;
+  z-index: 20000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2.4rem;
+  background: rgba(0, 0, 0, 0.82);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  opacity: 0;
+  transition: opacity 180ms ease;
+}
+
+.photo-lightbox.is-open {
+  opacity: 1;
+}
+
+.photo-lightbox-figure {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  max-width: calc(100vw - 12rem);
+  max-height: calc(100vh - 6rem);
+  margin: 0;
+  transform: scale(0.985);
+  transition: transform 180ms ease;
+}
+
+.photo-lightbox.is-open .photo-lightbox-figure {
+  transform: scale(1);
+}
+
+.photo-lightbox-figure img {
+  display: block;
+  width: auto;
+  height: auto;
+  max-width: 100%;
+  max-height: calc(100vh - 11rem);
+  border-radius: 0.4rem;
+  object-fit: contain;
+  box-shadow: 0 2rem 7rem rgba(0, 0, 0, 0.45);
+}
+
+.photo-lightbox-meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 2rem;
+  width: 100%;
+  margin-top: 1.2rem;
+  color: rgba(255, 255, 255, 0.72);
+  font-size: 1.3rem;
+}
+
+.photo-lightbox-meta [data-photo-lightbox-caption] {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.photo-lightbox-meta [data-photo-lightbox-count] {
+  flex: 0 0 auto;
+  font-family: "DM Mono", monospace;
+}
+
+.photo-lightbox button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 0;
+  color: rgba(255, 255, 255, 0.7);
+  background: rgba(0, 0, 0, 0.18);
+  cursor: pointer;
+  transition: color 160ms ease, background-color 160ms ease, opacity 160ms ease;
+}
+
+.photo-lightbox button:hover {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.photo-lightbox button svg {
+  width: 2.4rem;
+  height: 2.4rem;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.photo-lightbox-close {
+  position: absolute;
+  top: 2rem;
+  right: 2rem;
+  z-index: 2;
+  width: 4.4rem;
+  height: 4.4rem;
+  border-radius: 999px;
+}
+
+.photo-lightbox-nav {
+  position: absolute;
+  top: 50%;
+  z-index: 2;
+  width: 5rem;
+  height: 7rem;
+  border-radius: 0.8rem;
+  transform: translateY(-50%);
+}
+
+.photo-lightbox-prev {
+  left: 2rem;
+}
+
+.photo-lightbox-next {
+  right: 2rem;
+}
+
+body.photo-lightbox-open {
+  overflow: hidden;
+}
+
+@media screen and (min-width: 1700px) {
+  .photo-view-toggle {
+    position: fixed;
+    top: 8rem;
+    left: 2.4rem;
+    z-index: 20;
+  }
+}
+
+@media screen and (max-width: 1279px) {
+  .photo-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media screen and (max-width: 899px) {
+  .photo-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media screen and (max-width: 599px) {
+  .photo-gallery-page {
+    width: calc(100vw - 2rem);
+  }
+
+  .photo-gallery-header {
+    align-items: center;
+    margin-bottom: 1.6rem;
+  }
+
+  .photo-grid {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 1rem;
+  }
+
+  .photo-lightbox {
+    padding: 1rem;
+  }
+
+  .photo-lightbox-figure {
+    max-width: 100%;
+    max-height: calc(100vh - 2rem);
+  }
+
+  .photo-lightbox-figure img {
+    max-height: calc(100vh - 8rem);
+  }
+
+  .photo-lightbox-nav {
+    top: auto;
+    bottom: 1.6rem;
+    width: 4.4rem;
+    height: 4.4rem;
+    border-radius: 999px;
+    transform: none;
+  }
+
+  .photo-lightbox-prev {
+    left: 1.6rem;
+  }
+
+  .photo-lightbox-next {
+    right: 1.6rem;
+  }
+
+  .photo-lightbox-close {
+    top: 1.2rem;
+    right: 1.2rem;
+  }
+
+  .photo-lightbox-meta {
+    padding: 0 5.5rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .photo-item img,
+  .photo-item::after,
+  .photo-view-toggle,
+  .photo-lightbox,
+  .photo-lightbox-figure {
+    transition: none;
+  }
+}

--- a/static/js/gallery.js
+++ b/static/js/gallery.js
@@ -1,0 +1,179 @@
+(function () {
+  function ready(callback) {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', callback, { once: true });
+    } else {
+      callback();
+    }
+  }
+
+  ready(function () {
+    var gallery = document.querySelector('[data-photo-gallery]');
+    if (!gallery) return;
+
+    var toggle = gallery.querySelector('[data-photo-view-toggle]');
+    var items = Array.prototype.slice.call(gallery.querySelectorAll('.photo-item'));
+    var lightbox = gallery.querySelector('[data-photo-lightbox]');
+    var lightboxImage = gallery.querySelector('[data-photo-lightbox-image]');
+    var lightboxCaption = gallery.querySelector('[data-photo-lightbox-caption]');
+    var lightboxCount = gallery.querySelector('[data-photo-lightbox-count]');
+    var closeButton = gallery.querySelector('[data-photo-lightbox-close]');
+    var previousButton = gallery.querySelector('[data-photo-lightbox-prev]');
+    var nextButton = gallery.querySelector('[data-photo-lightbox-next]');
+
+    var activeIndex = -1;
+    var previousFocus = null;
+    var touchStartX = null;
+    var closeTimer = null;
+
+    function setView(view) {
+      var nextView = view === 'contain' ? 'contain' : 'cover';
+      gallery.setAttribute('data-view', nextView);
+
+      if (toggle) {
+        var isContain = nextView === 'contain';
+        var label = isContain
+          ? toggle.getAttribute('data-contain-label')
+          : toggle.getAttribute('data-cover-label');
+        toggle.setAttribute('aria-pressed', String(isContain));
+        if (label) toggle.setAttribute('aria-label', label);
+      }
+
+      try {
+        window.localStorage.setItem('photo-gallery-view', nextView);
+      } catch (error) {}
+    }
+
+    if (toggle) {
+      var savedView = null;
+      try {
+        savedView = window.localStorage.getItem('photo-gallery-view');
+      } catch (error) {}
+
+      setView(savedView === 'contain' ? 'contain' : 'cover');
+      toggle.addEventListener('click', function () {
+        setView(gallery.getAttribute('data-view') === 'cover' ? 'contain' : 'cover');
+      });
+    }
+
+    if (!lightbox || !lightboxImage || items.length === 0) return;
+
+    function getPhoto(index) {
+      var item = items[index];
+      var image = item && item.querySelector('img');
+      return {
+        src: item ? item.getAttribute('href') : '',
+        alt: item ? item.getAttribute('data-photo-alt') || (image && image.alt) || '' : ''
+      };
+    }
+
+    function preload(index) {
+      if (items.length < 2) return;
+      var normalizedIndex = (index + items.length) % items.length;
+      var photo = getPhoto(normalizedIndex);
+      if (!photo.src) return;
+      var image = new Image();
+      image.src = photo.src;
+    }
+
+    function render(index) {
+      activeIndex = (index + items.length) % items.length;
+      var photo = getPhoto(activeIndex);
+      if (!photo.src) return;
+
+      lightboxImage.src = photo.src;
+      lightboxImage.alt = photo.alt;
+      if (lightboxCaption) lightboxCaption.textContent = photo.alt;
+      if (lightboxCount) lightboxCount.textContent = String(activeIndex + 1) + ' / ' + String(items.length);
+
+      preload(activeIndex + 1);
+      preload(activeIndex - 1);
+    }
+
+    function open(index) {
+      if (closeTimer) {
+        window.clearTimeout(closeTimer);
+        closeTimer = null;
+      }
+
+      previousFocus = document.activeElement;
+      render(index);
+      lightbox.hidden = false;
+      document.body.classList.add('photo-lightbox-open');
+
+      window.requestAnimationFrame(function () {
+        lightbox.classList.add('is-open');
+      });
+
+      if (closeButton) closeButton.focus();
+    }
+
+    function close() {
+      if (lightbox.hidden) return;
+      lightbox.classList.remove('is-open');
+      document.body.classList.remove('photo-lightbox-open');
+
+      closeTimer = window.setTimeout(function () {
+        lightbox.hidden = true;
+        lightboxImage.removeAttribute('src');
+        activeIndex = -1;
+        closeTimer = null;
+      }, 180);
+
+      if (previousFocus && typeof previousFocus.focus === 'function') {
+        previousFocus.focus();
+      }
+      previousFocus = null;
+    }
+
+    function navigate(direction) {
+      if (activeIndex < 0) return;
+      render(activeIndex + direction);
+    }
+
+    items.forEach(function (item, index) {
+      item.addEventListener('click', function (event) {
+        event.preventDefault();
+        open(index);
+      });
+    });
+
+    if (closeButton) closeButton.addEventListener('click', close);
+    if (previousButton) previousButton.addEventListener('click', function () { navigate(-1); });
+    if (nextButton) nextButton.addEventListener('click', function () { navigate(1); });
+
+    lightbox.addEventListener('click', function (event) {
+      if (event.target === lightbox) close();
+    });
+
+    lightbox.addEventListener('touchstart', function (event) {
+      if (event.touches.length === 1) touchStartX = event.touches[0].clientX;
+    }, { passive: true });
+
+    lightbox.addEventListener('touchend', function (event) {
+      if (touchStartX === null || event.changedTouches.length !== 1) return;
+      var distance = event.changedTouches[0].clientX - touchStartX;
+      touchStartX = null;
+      if (Math.abs(distance) < 50) return;
+      navigate(distance > 0 ? -1 : 1);
+    }, { passive: true });
+
+    document.addEventListener('keydown', function (event) {
+      if (lightbox.hidden) return;
+
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        close();
+      } else if (event.key === 'ArrowLeft') {
+        event.preventDefault();
+        navigate(-1);
+      } else if (event.key === 'ArrowRight') {
+        event.preventDefault();
+        navigate(1);
+      } else if (event.key === 'Tab' && closeButton) {
+        event.preventDefault();
+        closeButton.focus();
+      }
+    });
+  });
+})();


### PR DESCRIPTION
## What changed

- Rebuilds the existing Gallery page around images in `assets/photos`
- Adds a responsive 1-4 column square grid inspired by antfu.me
- Adds cover/contain layout switching with the preference saved locally
- Adds a full-screen lightbox with captions, counters, keyboard navigation, and mobile swipe navigation
- Generates 900px WebP thumbnails while preserving original files for full-screen viewing
- Adds an Antfu-style camera icon in the navigation instead of a Photos/照片 text item
- Enables Git LFS checkout in Firebase production and preview workflows

## Why

The existing gallery layout only read page-bundle resources, so the newly uploaded Git LFS images under `assets/photos` could not appear. This implementation reads Hugo global resources directly and ensures CI checks out the LFS objects before building.

## Validation

- Compared against the current `master` branch
- Firebase PR build completed successfully with the LFS images and Hugo image processing
- Firebase preview deployment completed successfully
