### PR TITLE
Match Antfu photo gallery and fix image preview

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -34,13 +34,60 @@ jobs:
         env:
           ALGOLIA_ADMIN_KEY: ${{ secrets.ALGOLIA_ADMIN_KEY }}
         run: npm update && rm -rf public && hugo --minify && npm run index-and-send
-      - name: Verify gallery output
+      - name: Verify gallery output and assets
         run: |
-          test -f public/gallery/index.html
-          grep -q 'data-photo-gallery' public/gallery/index.html
-          photo_count=$(grep -o 'data-photo-index=' public/gallery/index.html | wc -l | tr -d ' ')
-          echo "Gallery generated ${photo_count} photo items"
-          test "${photo_count}" -ge 200
+          python - <<'PY'
+          from html.parser import HTMLParser
+          from pathlib import Path
+          from urllib.parse import unquote, urlparse
+          import subprocess
+
+          class GalleryParser(HTMLParser):
+              def __init__(self):
+                  super().__init__()
+                  self.sources = []
+
+              def handle_starttag(self, tag, attrs):
+                  source = dict(attrs).get("data-photo-src")
+                  if source:
+                      self.sources.append(source)
+
+          html_path = Path("public/gallery/index.html")
+          if not html_path.exists():
+              raise SystemExit("Missing public/gallery/index.html")
+
+          parser = GalleryParser()
+          parser.feed(html_path.read_text(encoding="utf-8"))
+          print(f"Gallery generated {len(parser.sources)} photo items")
+          if len(parser.sources) < 200:
+              raise SystemExit("Gallery contains fewer than 200 photo items")
+
+          failures = []
+          for source in parser.sources:
+              relative = unquote(urlparse(source).path).lstrip("/")
+              file_path = Path("public") / relative
+              if not file_path.is_file():
+                  failures.append(f"missing: {source}")
+                  continue
+              if file_path.stat().st_size < 1024:
+                  failures.append(f"too small: {source}")
+                  continue
+              if file_path.read_bytes()[:64].startswith(b"version https://git-lfs"):
+                  failures.append(f"LFS pointer: {source}")
+                  continue
+              mime = subprocess.check_output(
+                  ["file", "--brief", "--mime-type", str(file_path)],
+                  text=True,
+              ).strip()
+              if not mime.startswith("image/"):
+                  failures.append(f"not an image ({mime}): {source}")
+
+          if failures:
+              print("\n".join(failures[:20]))
+              raise SystemExit(f"{len(failures)} gallery assets failed validation")
+
+          print(f"Validated {len(parser.sources)} published image assets")
+          PY
       - name: Deploy to Firebase Hosting
         env:
           FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_BLOG_6A0BF }}

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -27,13 +27,60 @@ jobs:
         env:
           ALGOLIA_ADMIN_KEY: ${{ secrets.ALGOLIA_ADMIN_KEY }}
         run: npm update && rm -rf public && hugo --minify && npm run index-and-send
-      - name: Verify gallery output
+      - name: Verify gallery output and assets
         run: |
-          test -f public/gallery/index.html
-          grep -q 'data-photo-gallery' public/gallery/index.html
-          photo_count=$(grep -o 'data-photo-index=' public/gallery/index.html | wc -l | tr -d ' ')
-          echo "Gallery generated ${photo_count} photo items"
-          test "${photo_count}" -ge 200
+          python - <<'PY'
+          from html.parser import HTMLParser
+          from pathlib import Path
+          from urllib.parse import unquote, urlparse
+          import subprocess
+
+          class GalleryParser(HTMLParser):
+              def __init__(self):
+                  super().__init__()
+                  self.sources = []
+
+              def handle_starttag(self, tag, attrs):
+                  source = dict(attrs).get("data-photo-src")
+                  if source:
+                      self.sources.append(source)
+
+          html_path = Path("public/gallery/index.html")
+          if not html_path.exists():
+              raise SystemExit("Missing public/gallery/index.html")
+
+          parser = GalleryParser()
+          parser.feed(html_path.read_text(encoding="utf-8"))
+          print(f"Gallery generated {len(parser.sources)} photo items")
+          if len(parser.sources) < 200:
+              raise SystemExit("Gallery contains fewer than 200 photo items")
+
+          failures = []
+          for source in parser.sources:
+              relative = unquote(urlparse(source).path).lstrip("/")
+              file_path = Path("public") / relative
+              if not file_path.is_file():
+                  failures.append(f"missing: {source}")
+                  continue
+              if file_path.stat().st_size < 1024:
+                  failures.append(f"too small: {source}")
+                  continue
+              if file_path.read_bytes()[:64].startswith(b"version https://git-lfs"):
+                  failures.append(f"LFS pointer: {source}")
+                  continue
+              mime = subprocess.check_output(
+                  ["file", "--brief", "--mime-type", str(file_path)],
+                  text=True,
+              ).strip()
+              if not mime.startswith("image/"):
+                  failures.append(f"not an image ({mime}): {source}")
+
+          if failures:
+              print("\n".join(failures[:20]))
+              raise SystemExit(f"{len(failures)} gallery assets failed validation")
+
+          print(f"Validated {len(parser.sources)} published image assets")
+          PY
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"

--- a/layouts/gallery/list.html
+++ b/layouts/gallery/list.html
@@ -19,68 +19,55 @@
 {{ $images = sort $images "Name" "desc" }}
 {{ $isZh := eq .Site.Language.Lang "zh-CN" }}
 
-<link rel="stylesheet" href="/css/gallery.css?v=20260711d" />
+<link rel="stylesheet" href="/css/gallery.css?v=20260711e" />
+<script>document.body.classList.add('page-gallery');</script>
 
 <section class="photo-gallery-page" data-photo-gallery data-view="cover" data-photo-count="{{ len $images }}">
-  <header class="photo-gallery-header">
-    <div class="photo-gallery-heading">
-      <h1 class="title">{{ .Title }}</h1>
-      {{ with .Description }}
-      <p class="photo-gallery-description">{{ . }}</p>
-      {{ end }}
-    </div>
-
-    {{ if gt (len $images) 0 }}
-    <button
-      class="photo-view-toggle"
-      type="button"
-      data-photo-view-toggle
-      data-cover-label="{{ if $isZh }}切换为完整图片视图{{ else }}Switch to full-image view{{ end }}"
-      data-contain-label="{{ if $isZh }}切换为裁切网格视图{{ else }}Switch to cropped grid view{{ end }}"
-      aria-label="{{ if $isZh }}切换为完整图片视图{{ else }}Switch to full-image view{{ end }}"
-      aria-pressed="false"
-      title="{{ if $isZh }}切换图片布局{{ else }}Switch photo layout{{ end }}"
-    >
-      <svg class="photo-view-icon photo-view-icon-cover" viewBox="0 0 24 24" aria-hidden="true">
-        <path d="M4 4h6v6H4zM14 4h6v6h-6zM4 14h6v6H4zM14 14h6v6h-6z" />
-      </svg>
-      <svg class="photo-view-icon photo-view-icon-contain" viewBox="0 0 24 24" aria-hidden="true">
-        <path d="M4 5h16v14H4zM7 16l3.5-4 2.5 3 2-2 2 3H7zM16.5 8.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z" />
-      </svg>
-    </button>
-    {{ end }}
-  </header>
-
   {{ if gt (len $images) 0 }}
-  <div
-    class="photo-grid photos"
-    role="list"
-    aria-label="{{ if $isZh }}照片集{{ else }}Photo gallery{{ end }}"
+  <button
+    class="photo-view-toggle"
+    type="button"
+    data-photo-view-toggle
+    data-cover-label="{{ if $isZh }}切换为完整图片视图{{ else }}Switch to full-image view{{ end }}"
+    data-contain-label="{{ if $isZh }}切换为裁切网格视图{{ else }}Switch to cropped grid view{{ end }}"
+    aria-label="{{ if $isZh }}切换为完整图片视图{{ else }}Switch to full-image view{{ end }}"
+    aria-pressed="false"
+    title="{{ if $isZh }}切换图片布局{{ else }}Switch photo layout{{ end }}"
   >
+    <svg class="photo-view-icon photo-view-icon-cover" viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M4 4h6v6H4zM14 4h6v6h-6zM4 14h6v6H4zM14 14h6v6h-6z" />
+    </svg>
+    <svg class="photo-view-icon photo-view-icon-contain" viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M4 5h16v14H4zM7 16l3.5-4 2.5 3 2-2 2 3H7zM16.5 8.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z" />
+    </svg>
+  </button>
+
+  <div class="photo-grid photos" role="list" aria-label="{{ if $isZh }}照片集{{ else }}Photo gallery{{ end }}">
     {{ range $index, $image := $images }}
+      {{ $extension := lower (path.Ext $image.Name) }}
       {{ $baseName := path.BaseName $image.Name }}
       {{ $alt := humanize (replaceRE `[-_]+` " " $baseName) }}
-    <a
+      {{ $safeName := printf "%04d-%s%s" $index (urlize $baseName) $extension }}
+      {{ $published := resources.Copy (printf "gallery/%s" $safeName) $image }}
+    <button
       class="photo-item"
-      href="{{ $image.RelPermalink }}"
+      type="button"
       role="listitem"
       data-photo-index="{{ $index }}"
+      data-photo-src="{{ $published.RelPermalink }}"
       data-photo-alt="{{ $alt }}"
       aria-label="{{ if $isZh }}查看照片：{{ $alt }}{{ else }}View photo: {{ $alt }}{{ end }}"
     >
       <img
-        src="{{ $image.RelPermalink }}"
+        src="{{ $published.RelPermalink }}"
         alt="{{ $alt }}"
+        data-gallery-image
         loading="lazy"
         decoding="async"
       />
-    </a>
+    </button>
     {{ end }}
   </div>
-
-  <p class="photo-gallery-note">
-    {{ if $isZh }}共 {{ len $images }} 张照片。谢谢你愿意看看这些被留下来的瞬间。{{ else }}{{ len $images }} photos. Thank you for taking a look at the moments I chose to keep.{{ end }}
-  </p>
 
   <div
     class="photo-lightbox"
@@ -90,6 +77,8 @@
     aria-label="{{ if $isZh }}照片预览{{ else }}Photo preview{{ end }}"
     hidden
   >
+    <div class="photo-lightbox-backdrop" aria-hidden="true"></div>
+
     <button
       class="photo-lightbox-close"
       type="button"
@@ -108,13 +97,7 @@
       <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m15 5-7 7 7 7" /></svg>
     </button>
 
-    <figure class="photo-lightbox-figure">
-      <img data-photo-lightbox-image src="" alt="" />
-      <figcaption class="photo-lightbox-meta">
-        <span data-photo-lightbox-caption></span>
-        <span data-photo-lightbox-count></span>
-      </figcaption>
-    </figure>
+    <img class="photo-lightbox-image" data-photo-lightbox-image src="" alt="" />
 
     <button
       class="photo-lightbox-nav photo-lightbox-next"
@@ -124,6 +107,11 @@
     >
       <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m9 5 7 7-7 7" /></svg>
     </button>
+
+    <div class="photo-lightbox-meta">
+      <span data-photo-lightbox-caption></span>
+      <span data-photo-lightbox-count></span>
+    </div>
   </div>
   {{ else }}
   <p class="photo-gallery-empty">
@@ -132,5 +120,5 @@
   {{ end }}
 </section>
 
-<script defer src="/js/gallery.js?v=20260711d"></script>
+<script defer src="/js/gallery.js?v=20260711e"></script>
 {{ end }}

--- a/static/css/gallery.css
+++ b/static/css/gallery.css
@@ -1,53 +1,59 @@
-/* Antfu-inspired photo gallery */
+/* Full-width photo gallery inspired by antfu.me */
+body.page-gallery,
+body.page-gallery .wrapper,
+body.page-gallery .content {
+  width: 100% !important;
+  max-width: none !important;
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+body.page-gallery .navigation,
+body.page-gallery .footer,
+body.page-gallery #adsense-container,
+body.page-gallery > .float,
+.wrapper:has(.photo-gallery-page) > .navigation,
+.wrapper:has(.photo-gallery-page) > .footer,
+.wrapper:has(.photo-gallery-page) #adsense-container {
+  display: none !important;
+}
+
+body.page-gallery .content {
+  min-height: 100vh;
+}
+
 .photo-gallery-page {
   position: relative;
-  left: 50%;
-  width: min(160rem, calc(100vw - 3.2rem));
-  transform: translateX(-50%);
-}
-
-.photo-gallery-header {
-  display: flex;
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: 2rem;
-  max-width: 65ch;
-  margin: 0 auto 2.4rem;
-}
-
-.photo-gallery-heading {
-  min-width: 0;
-}
-
-.photo-gallery-header .title {
-  margin-bottom: 0.6rem;
-}
-
-.photo-gallery-description {
-  margin: 0;
-  color: var(--c-fg-light);
+  width: 100%;
+  min-height: 100vh;
+  padding: 7.2rem 1.6rem 3.2rem;
+  background: var(--c-bg);
 }
 
 .photo-view-toggle {
+  position: fixed;
+  top: 2.2rem;
+  left: 2.2rem;
+  z-index: 120;
   display: inline-flex;
-  flex: 0 0 auto;
   align-items: center;
   justify-content: center;
-  width: 4rem;
-  height: 4rem;
+  width: 3.4rem;
+  height: 3.4rem;
   padding: 0;
   border: 0;
   border-radius: 999px;
   color: var(--c-fg-light);
   background: transparent;
+  opacity: 0.28;
   cursor: pointer;
-  transition: color 160ms ease, background-color 160ms ease, transform 160ms ease;
+  transition: opacity 160ms ease, background-color 160ms ease, transform 160ms ease;
 }
 
 .photo-view-toggle:hover,
 .photo-view-toggle:focus-visible {
-  color: var(--c-fg-deeper);
   background: rgba(125, 125, 125, 0.1);
+  opacity: 1;
 }
 
 .photo-view-toggle:active {
@@ -62,11 +68,11 @@
 }
 
 .photo-view-icon {
-  width: 2rem;
-  height: 2rem;
+  width: 1.8rem;
+  height: 1.8rem;
   fill: none;
   stroke: currentColor;
-  stroke-width: 1.7;
+  stroke-width: 1.65;
   stroke-linecap: round;
   stroke-linejoin: round;
 }
@@ -90,20 +96,24 @@
 
 .photo-grid {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: minmax(0, 1fr);
   gap: 1.6rem;
-  max-width: 160rem;
+  width: 100%;
+  max-width: 200rem;
   margin: 0 auto;
 }
 
 .photo-item {
   position: relative;
   display: block;
+  width: 100%;
   aspect-ratio: 1;
+  padding: 0;
   overflow: hidden;
   border: 0 !important;
   border-radius: 0;
-  background: rgba(125, 125, 125, 0.06);
+  color: inherit;
+  background: rgba(125, 125, 125, 0.07);
   cursor: zoom-in;
   content-visibility: auto;
   contain-intrinsic-size: 32rem;
@@ -112,15 +122,14 @@
 .photo-item::after {
   position: absolute;
   inset: 0;
-  border: 1px solid transparent;
   pointer-events: none;
   content: "";
-  transition: border-color 180ms ease, background-color 180ms ease;
+  background: transparent;
+  transition: background-color 160ms ease;
 }
 
 .photo-item:hover::after {
-  border-color: rgba(255, 255, 255, 0.2);
-  background: rgba(0, 0, 0, 0.04);
+  background: rgba(0, 0, 0, 0.035);
 }
 
 .photo-item img {
@@ -129,34 +138,27 @@
   height: 100%;
   object-fit: cover;
   transform: scale(1.001);
-  transition: transform 280ms ease, opacity 280ms ease;
+  transition: opacity 180ms ease, transform 220ms ease;
 }
 
 .photo-item:hover img {
-  transform: scale(1.025);
+  transform: scale(1.012);
 }
 
 .photo-gallery-page[data-view="contain"] .photo-item {
-  background: rgba(125, 125, 125, 0.075);
+  background: rgba(125, 125, 125, 0.055);
 }
 
 .photo-gallery-page[data-view="contain"] .photo-item img {
   object-fit: contain;
-  padding: 0.8rem;
   transform: none;
 }
 
-.photo-gallery-page[data-view="contain"] .photo-item:hover img {
-  opacity: 0.88;
-}
-
-.photo-gallery-note,
 .photo-gallery-empty {
   max-width: 65ch;
-  margin: 3.2rem auto 0;
+  margin: 12rem auto;
   color: var(--c-fg-light);
-  font-size: 1.35rem;
-  font-style: italic;
+  text-align: center;
 }
 
 .photo-lightbox[hidden] {
@@ -166,14 +168,11 @@
 .photo-lightbox {
   position: fixed;
   inset: 0;
-  z-index: 20000;
+  z-index: 30000;
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 2.4rem;
-  background: rgba(0, 0, 0, 0.82);
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
+  padding: 0;
   opacity: 0;
   transition: opacity 180ms ease;
 }
@@ -182,41 +181,46 @@
   opacity: 1;
 }
 
-.photo-lightbox-figure {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  max-width: calc(100vw - 12rem);
-  max-height: calc(100vh - 6rem);
-  margin: 0;
-  transform: scale(0.985);
-  transition: transform 180ms ease;
+.photo-lightbox-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.64);
+  backdrop-filter: blur(2.8rem);
+  -webkit-backdrop-filter: blur(2.8rem);
 }
 
-.photo-lightbox.is-open .photo-lightbox-figure {
+.photo-lightbox-image {
+  position: relative;
+  z-index: 1;
+  display: block;
+  width: 100vw;
+  height: 100vh;
+  padding: 2.4rem;
+  object-fit: contain;
+  opacity: 0;
+  transform: scale(0.99);
+  transition: opacity 160ms ease, transform 180ms ease;
+  cursor: zoom-out;
+}
+
+.photo-lightbox-image.is-loaded {
+  opacity: 1;
   transform: scale(1);
 }
 
-.photo-lightbox-figure img {
-  display: block;
-  width: auto;
-  height: auto;
-  max-width: 100%;
-  max-height: calc(100vh - 11rem);
-  border-radius: 0.4rem;
-  object-fit: contain;
-  box-shadow: 0 2rem 7rem rgba(0, 0, 0, 0.45);
-}
-
 .photo-lightbox-meta {
+  position: absolute;
+  right: 2rem;
+  bottom: 2rem;
+  z-index: 3;
   display: flex;
-  justify-content: space-between;
-  gap: 2rem;
-  width: 100%;
-  margin-top: 1.2rem;
-  color: rgba(255, 255, 255, 0.72);
-  font-size: 1.3rem;
+  align-items: center;
+  gap: 1rem;
+  max-width: min(70vw, 80rem);
+  padding: 0.55rem 0.9rem;
+  color: rgba(255, 255, 255, 0.82);
+  font-size: 1.25rem;
+  background: rgba(0, 0, 0, 0.46);
 }
 
 .photo-lightbox-meta [data-photo-lightbox-caption] {
@@ -231,13 +235,16 @@
 }
 
 .photo-lightbox button {
+  position: absolute;
+  z-index: 4;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   padding: 0;
   border: 0;
-  color: rgba(255, 255, 255, 0.7);
+  color: rgba(255, 255, 255, 0.58);
   background: rgba(0, 0, 0, 0.18);
+  opacity: 0.52;
   cursor: pointer;
   transition: color 160ms ease, background-color 160ms ease, opacity 160ms ease;
 }
@@ -245,11 +252,12 @@
 .photo-lightbox button:hover {
   color: #fff;
   background: rgba(255, 255, 255, 0.12);
+  opacity: 1;
 }
 
 .photo-lightbox button svg {
-  width: 2.4rem;
-  height: 2.4rem;
+  width: 2.2rem;
+  height: 2.2rem;
   fill: none;
   stroke: currentColor;
   stroke-width: 1.8;
@@ -258,110 +266,109 @@
 }
 
 .photo-lightbox-close {
-  position: absolute;
-  top: 2rem;
-  right: 2rem;
-  z-index: 2;
-  width: 4.4rem;
-  height: 4.4rem;
+  top: 1.8rem;
+  right: 1.8rem;
+  width: 4.2rem;
+  height: 4.2rem;
   border-radius: 999px;
 }
 
 .photo-lightbox-nav {
-  position: absolute;
   top: 50%;
-  z-index: 2;
-  width: 5rem;
+  width: 4.8rem;
   height: 7rem;
   border-radius: 0.8rem;
   transform: translateY(-50%);
 }
 
 .photo-lightbox-prev {
-  left: 2rem;
+  left: 1.6rem;
 }
 
 .photo-lightbox-next {
-  right: 2rem;
+  right: 1.6rem;
 }
 
 body.photo-lightbox-open {
   overflow: hidden;
 }
 
-@media screen and (min-width: 1700px) {
-  .photo-view-toggle {
-    position: fixed;
-    top: 8rem;
-    left: 2.4rem;
-    z-index: 20;
-  }
-}
-
-@media screen and (max-width: 1279px) {
-  .photo-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-}
-
-@media screen and (max-width: 899px) {
+@media screen and (min-width: 768px) {
   .photo-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
+@media screen and (min-width: 1024px) {
+  .photo-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media screen and (min-width: 1280px) {
+  .photo-grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
 @media screen and (max-width: 599px) {
   .photo-gallery-page {
-    width: calc(100vw - 2rem);
+    padding: 6rem 1rem 2rem;
   }
 
-  .photo-gallery-header {
-    align-items: center;
-    margin-bottom: 1.6rem;
+  .photo-view-toggle {
+    top: 1.4rem;
+    left: 1.4rem;
   }
 
   .photo-grid {
-    grid-template-columns: minmax(0, 1fr);
     gap: 1rem;
   }
 
-  .photo-lightbox {
+  .photo-gallery-page[data-view="contain"] .photo-item {
+    aspect-ratio: auto;
+  }
+
+  .photo-gallery-page[data-view="contain"] .photo-item img {
+    height: auto;
+    min-height: 0;
+  }
+
+  .photo-lightbox-image {
     padding: 1rem;
-  }
-
-  .photo-lightbox-figure {
-    max-width: 100%;
-    max-height: calc(100vh - 2rem);
-  }
-
-  .photo-lightbox-figure img {
-    max-height: calc(100vh - 8rem);
   }
 
   .photo-lightbox-nav {
     top: auto;
-    bottom: 1.6rem;
-    width: 4.4rem;
-    height: 4.4rem;
+    bottom: 1.2rem;
+    width: 4.2rem;
+    height: 4.2rem;
     border-radius: 999px;
     transform: none;
   }
 
   .photo-lightbox-prev {
-    left: 1.6rem;
+    left: 1.2rem;
   }
 
   .photo-lightbox-next {
-    right: 1.6rem;
-  }
-
-  .photo-lightbox-close {
-    top: 1.2rem;
     right: 1.2rem;
   }
 
+  .photo-lightbox-close {
+    top: 1rem;
+    right: 1rem;
+  }
+
   .photo-lightbox-meta {
-    padding: 0 5.5rem;
+    right: 50%;
+    bottom: 1.35rem;
+    max-width: calc(100vw - 12rem);
+    transform: translateX(50%);
+  }
+
+  .photo-lightbox-meta [data-photo-lightbox-caption] {
+    display: none;
   }
 }
 
@@ -370,7 +377,7 @@ body.photo-lightbox-open {
   .photo-item::after,
   .photo-view-toggle,
   .photo-lightbox,
-  .photo-lightbox-figure {
+  .photo-lightbox-image {
     transition: none;
   }
 }

--- a/static/js/gallery.js
+++ b/static/js/gallery.js
@@ -11,6 +11,8 @@
     var gallery = document.querySelector('[data-photo-gallery]');
     if (!gallery) return;
 
+    document.body.classList.add('page-gallery');
+
     var toggle = gallery.querySelector('[data-photo-view-toggle]');
     var items = Array.prototype.slice.call(gallery.querySelectorAll('.photo-item'));
     var lightbox = gallery.querySelector('[data-photo-lightbox]');
@@ -58,31 +60,56 @@
 
     if (!lightbox || !lightboxImage || items.length === 0) return;
 
+    function normalizeIndex(index) {
+      return (index + items.length) % items.length;
+    }
+
     function getPhoto(index) {
       var item = items[index];
       var image = item && item.querySelector('img');
+      var src = '';
+
+      if (image) {
+        src = image.currentSrc || image.src || '';
+      }
+      if (!src && item) {
+        src = item.getAttribute('data-photo-src') || '';
+      }
+
       return {
-        src: item ? item.getAttribute('href') : '',
+        src: src,
         alt: item ? item.getAttribute('data-photo-alt') || (image && image.alt) || '' : ''
       };
     }
 
     function preload(index) {
       if (items.length < 2) return;
-      var normalizedIndex = (index + items.length) % items.length;
-      var photo = getPhoto(normalizedIndex);
+      var photo = getPhoto(normalizeIndex(index));
       if (!photo.src) return;
       var image = new Image();
+      image.decoding = 'async';
       image.src = photo.src;
     }
 
     function render(index) {
-      activeIndex = (index + items.length) % items.length;
+      activeIndex = normalizeIndex(index);
       var photo = getPhoto(activeIndex);
       if (!photo.src) return;
 
-      lightboxImage.src = photo.src;
+      lightboxImage.classList.remove('is-loaded');
       lightboxImage.alt = photo.alt;
+      lightboxImage.onload = function () {
+        lightboxImage.classList.add('is-loaded');
+      };
+      lightboxImage.onerror = function () {
+        lightboxImage.classList.remove('is-loaded');
+      };
+      lightboxImage.src = photo.src;
+
+      if (lightboxImage.complete && lightboxImage.naturalWidth > 0) {
+        lightboxImage.classList.add('is-loaded');
+      }
+
       if (lightboxCaption) lightboxCaption.textContent = photo.alt;
       if (lightboxCount) lightboxCount.textContent = String(activeIndex + 1) + ' / ' + String(items.length);
 
@@ -97,9 +124,9 @@
       }
 
       previousFocus = document.activeElement;
-      render(index);
       lightbox.hidden = false;
       document.body.classList.add('photo-lightbox-open');
+      render(index);
 
       window.requestAnimationFrame(function () {
         lightbox.classList.add('is-open');
@@ -116,6 +143,7 @@
       closeTimer = window.setTimeout(function () {
         lightbox.hidden = true;
         lightboxImage.removeAttribute('src');
+        lightboxImage.classList.remove('is-loaded');
         activeIndex = -1;
         closeTimer = null;
       }, 180);
@@ -132,8 +160,7 @@
     }
 
     items.forEach(function (item, index) {
-      item.addEventListener('click', function (event) {
-        event.preventDefault();
+      item.addEventListener('click', function () {
         open(index);
       });
     });
@@ -143,7 +170,13 @@
     if (nextButton) nextButton.addEventListener('click', function () { navigate(1); });
 
     lightbox.addEventListener('click', function (event) {
-      if (event.target === lightbox) close();
+      if (
+        event.target === lightbox ||
+        event.target === lightboxImage ||
+        (event.target && event.target.classList && event.target.classList.contains('photo-lightbox-backdrop'))
+      ) {
+        close();
+      }
     });
 
     lightbox.addEventListener('touchstart', function (event) {


### PR DESCRIPTION
## What changed

- Reworks `/gallery/` into an immersive full-width photo grid matching antfu.me's 1/2/3/4-column responsive layout
- Hides the normal header, title, description, ads, and footer on the gallery page
- Moves the layout toggle to a subtle fixed control in the top-left corner
- Publishes every source photo to a URL-safe path without spaces before rendering
- Uses the thumbnail image's actual `currentSrc` for the lightbox, so the enlarged image always uses the same working URL
- Simplifies the lightbox to a full-viewport contain view with keyboard, click, and swipe navigation
- Adds CI validation for all published gallery files, MIME types, file sizes, and accidental Git LFS pointer files

## Root cause

The gallery rendered source asset URLs containing original filenames and spaces. The grid and lightbox also used different URL sources (`src` versus anchor `href`), so a path that failed in the grid also failed when enlarged. The deployment checks only counted markup and did not verify that the published image files actually existed.

## Reference

The layout follows antfu.me's full-width page and `PhotoGrid` behavior: square `object-cover` tiles, 1/2/3/4 responsive columns, 16px gaps, a fixed top-left cover/contain toggle, and a full-screen contained preview.

## Validation

The Firebase preview workflow will now fail unless it finds at least 200 gallery items and validates every published image file as a real image rather than a missing file or LFS pointer.