### PR TITLE
Fix Investing route and reorganize header navigation

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -25,7 +25,7 @@ pygmentscodefencesguesssyntax = true
       icon = "1"
       description = "Felix Mao（毛毛星）的个人知识站，记录 AI 编程、AI 个体创业、前端工程、创作者工作流、系统思维和长期投资实践。"
       keywords = "毛毛星,Felix Mao,maoxunxing,AI创作者,AI个体创业,AI编程,独立开发,前端工程师,创作者工作流,个人知识系统,长期投资"
-      custom_css = ["/css/main.css?v=20260710b", "/css/code-dark.css?v=20260626a", "/css/home.css?v=20260626a", "/css/prompts.css?v=20260626a", "/css/p0-fixes.css?v=20260626a", "/css/nav-hotfix.css?v=20260710b", "/css/projects.css?v=20260710b", "/css/series.css?v=20260709a"]
+      custom_css = ["/css/main.css?v=20260710b", "/css/code-dark.css?v=20260626a", "/css/home.css?v=20260626a", "/css/prompts.css?v=20260626a", "/css/p0-fixes.css?v=20260626a", "/css/nav-hotfix.css?v=20260711a", "/css/projects.css?v=20260710b", "/css/series.css?v=20260709a"]
       custom_js = ["/js/home-dots-simplex.js?v=20260710b"]
   [languages.en]
     languageName = "EN"
@@ -34,7 +34,7 @@ pygmentscodefencesguesssyntax = true
     [languages.en.params]
       description = "Felix Mao's personal knowledge site about AI coding, AI indie hacking, frontend engineering, creator workflows, systems thinking, and long-term investing."
       keywords = "Felix Mao,maoxunxing,AI creator,AI indie hacking,AI coding,frontend engineer,indie hacker,creator workflows,personal knowledge system,long-term investing"
-      custom_css = ["/css/main.css?v=20260710b", "/css/code-dark.css?v=20260626a", "/css/home.css?v=20260626a", "/css/prompts.css?v=20260626a", "/css/p0-fixes.css?v=20260626a", "/css/nav-hotfix.css?v=20260710b", "/css/projects.css?v=20260710b", "/css/series.css?v=20260709a"]
+      custom_css = ["/css/main.css?v=20260710b", "/css/code-dark.css?v=20260626a", "/css/home.css?v=20260626a", "/css/prompts.css?v=20260626a", "/css/p0-fixes.css?v=20260626a", "/css/nav-hotfix.css?v=20260711a", "/css/projects.css?v=20260710b", "/css/series.css?v=20260709a"]
       custom_js = ["/js/home-dots-simplex.js?v=20260710b"]
 
 [markup]
@@ -95,7 +95,7 @@ long-term-investing = "/:slugorfilename/"
   hidecredits = false
   hidecopyright = false
   rtl = false
-  custom_css = ["/css/main.css?v=20260710b", "/css/code-dark.css?v=20260626a", "/css/home.css?v=20260626a", "/css/prompts.css?v=20260626a", "/css/p0-fixes.css?v=20260626a", "/css/nav-hotfix.css?v=20260710b", "/css/projects.css?v=20260710b", "/css/series.css?v=20260709a"]
+  custom_css = ["/css/main.css?v=20260710b", "/css/code-dark.css?v=20260626a", "/css/home.css?v=20260626a", "/css/prompts.css?v=20260626a", "/css/p0-fixes.css?v=20260626a", "/css/nav-hotfix.css?v=20260711a", "/css/projects.css?v=20260710b", "/css/series.css?v=20260709a"]
   custom_js = ["/js/home-dots-simplex.js?v=20260710b"]
   photoWidths = [300, 600, 800, 1200]
   colorscheme = "auto"
@@ -143,24 +143,24 @@ resampleFilter = "Lanczos"
   pageRef = "/posts"
   weight = 1
 [[languages.en.menu.main]]
-  name = "Investing"
-  pageRef = "/long-term-investing"
-  weight = 2
-[[languages.en.menu.main]]
   name = "AI Startup"
   pageRef = "/ai-indie-hacking"
-  weight = 3
+  weight = 2
 [[languages.en.menu.main]]
   name = "AI Coding"
   pageRef = "/ai-coding-workflow"
-  weight = 4
+  weight = 3
 [[languages.en.menu.main]]
   name = "Creator"
   pageRef = "/creator-workflow"
-  weight = 5
+  weight = 4
 [[languages.en.menu.main]]
   name = "Projects"
   pageRef = "/projects"
+  weight = 5
+[[languages.en.menu.main]]
+  name = "Investing"
+  pageRef = "/long-term-investing"
   weight = 6
 [[languages.en.menu.main]]
   name = "About"
@@ -171,24 +171,24 @@ resampleFilter = "Lanczos"
   pageRef = "/posts"
   weight = 1
 [[languages.zh-CN.menu.main]]
-  name = "长期投资"
-  pageRef = "/long-term-investing"
-  weight = 2
-[[languages.zh-CN.menu.main]]
   name = "AI创业"
   pageRef = "/ai-indie-hacking"
-  weight = 3
+  weight = 2
 [[languages.zh-CN.menu.main]]
   name = "AI编程"
   pageRef = "/ai-coding-workflow"
-  weight = 4
+  weight = 3
 [[languages.zh-CN.menu.main]]
   name = "创作系统"
   pageRef = "/creator-workflow"
-  weight = 5
+  weight = 4
 [[languages.zh-CN.menu.main]]
   name = "项目"
   pageRef = "/projects"
+  weight = 5
+[[languages.zh-CN.menu.main]]
+  name = "长期投资"
+  pageRef = "/long-term-investing"
   weight = 6
 [[languages.zh-CN.menu.main]]
   name = "关于"

--- a/content/long-term-investing/_index.md
+++ b/content/long-term-investing/_index.md
@@ -1,0 +1,82 @@
+---
+title: "Long-Term Investing & Family Cash Flow"
+date: 2026-07-09
+url: "/long-term-investing/"
+description: "Felix Mao's notes on long-term investing, family cash flow, asset allocation, mortgages, index funds, gold, bonds, and crypto assets."
+tags:
+  - Long-Term Investing
+  - Family Cash Flow
+  - Asset Allocation
+  - Compounding
+---
+
+# Long-Term Investing & Family Cash Flow
+
+I am not trying to build a collection of isolated trades. I want to understand how an ordinary family can place income, a mortgage, emergency cash, index funds, bonds, gold, and crypto assets inside one coherent system.
+
+It is easy to let a single asset dominate the conversation: whether an ETF is attractive, whether technology will keep outperforming, whether Bitcoin is still worth owning, or whether paying down a mortgage is safer than investing.
+
+Over time, I have found that the more important question is not how to capture every opportunity. It is how to prevent the family's financial structure from becoming fragile.
+
+Different assets should do different jobs:
+
+- cash and short-term bonds provide liquidity and protection;
+- broad-market index funds form the long-term core;
+- technology funds and other concentrated positions provide growth exposure;
+- gold helps diversify extreme risks;
+- crypto assets remain a small, high-volatility allocation.
+
+The purpose of this section is to document a long-term system that can continue through job changes, market drawdowns, higher family expenses, and changing financial goals.
+
+## Start with the family's real cash flow
+
+Investment capacity is not determined only by risk tolerance. It is also determined by whether the household can continue operating when risk becomes real.
+
+Before increasing exposure to volatile assets, I look at:
+
+- essential annual spending;
+- mortgage payments and other fixed obligations;
+- emergency reserves;
+- large expenses expected over the next few years;
+- the stability of employment income;
+- the possibility of being forced to sell during a market decline.
+
+A portfolio can be reasonable in theory and still fail in practice if the family needs the money at the wrong time.
+
+> The ability to take risk does not come only from courage. It comes from having enough cash flow to stay invested after the risk appears.
+
+## Core assets and growth assets solve different problems
+
+I used to treat the asset I liked most as the asset that deserved the largest allocation. That is not always the same as building a resilient portfolio.
+
+Broad-market funds are closer to core assets because they represent a wider part of the economy and depend less on one industry or trend. Technology funds can still be excellent growth assets, but they are more concentrated and more dependent on continued earnings growth and market expectations.
+
+Crypto assets have even greater upside and downside. For a family portfolio, they are better treated as a limited high-risk allocation than as the foundation of the entire financial plan.
+
+The roles are different:
+
+- core assets help the portfolio survive for a long time;
+- growth assets aim for returns above the broad market;
+- family cash flow determines how much concentration the household can safely carry.
+
+> A growth asset can remain my highest-conviction investment without becoming the only asset responsible for my family's future.
+
+## Investing versus paying down the mortgage
+
+This decision cannot be reduced to comparing the mortgage rate with an expected market return.
+
+Paying down debt provides certainty and lowers fixed obligations. Continuing to invest preserves liquidity and long-term growth potential. The better balance depends on job stability, cash reserves, family expenses, investment horizon, and the amount of volatility the household can actually tolerate.
+
+My practical order is:
+
+1. keep enough liquidity for emergencies and near-term expenses;
+2. avoid a portfolio that would force selling during a downturn;
+3. maintain a diversified long-term core;
+4. use concentrated growth assets only within a clearly limited risk budget;
+5. revisit the balance when income, debt, or family responsibilities change.
+
+## What this section is for
+
+This section will cover concrete assets, accounts, allocation methods, and personal decisions. The goal is not to provide short-term trading instructions or predict the next market cycle.
+
+The goal is to build a reusable framework for deciding what each asset is supposed to do, how much risk the family can carry, and how to keep the plan running for many years.

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -70,46 +70,6 @@
             </svg>
           </a>
 
-          <button
-            type="button"
-            id="dark-mode-toggle"
-            title="Toggle color scheme"
-            aria-label="Toggle color scheme"
-            aria-pressed="false"
-            class="nav-icon-link nav-icon-button"
-          >
-            <svg
-              class="inline dark-mode-icon"
-              width="1.2em"
-              height="1.2em"
-              preserveAspectRatio="xMidYMid meet"
-              viewBox="0 0 24 24"
-              style="vertical-align: sub;"
-              aria-hidden="true"
-              focusable="false"
-            >
-              <path
-                d="M10 7a7 7 0 0 0 12 4.9v.1c0 5.523-4.477 10-10 10S2 17.523 2 12S6.477 2 12 2h.1A6.979 6.979 0 0 0 10 7zm-6 5a8 8 0 0 0 15.062 3.762A9 9 0 0 1 8.238 4.938A7.999 7.999 0 0 0 4 12z"
-                fill="currentColor"
-              ></path>
-            </svg>
-            <svg
-              class="inline light-mode-icon"
-              width="1.2em"
-              height="1.2em"
-              preserveAspectRatio="xMidYMid meet"
-              viewBox="0 0 24 24"
-              style="vertical-align: sub;"
-              aria-hidden="true"
-              focusable="false"
-            >
-              <path
-                d="M12 18a6 6 0 1 1 0-12a6 6 0 0 1 0 12zm0-2a4 4 0 1 0 0-8a4 4 0 0 0 0 8zM11 1h2v3h-2V1zm0 19h2v3h-2v-3zM3.515 4.929l1.414-1.414L7.05 5.636L5.636 7.05L3.515 4.93zM16.95 18.364l1.414-1.414l2.121 2.121l-1.414 1.414l-2.121-2.121zm2.121-14.85l1.414 1.415l-2.121 2.121l-1.414-1.414l2.121-2.121zM5.636 16.95l1.414 1.414l-2.121 2.121l-1.414-1.414l2.121-2.121zM23 11v2h-3v-2h3zM4 11v2H1v-2h3z"
-                fill="currentColor"
-              ></path>
-            </svg>
-          </button>
-
           {{ if hugo.IsMultilingual }}
           {{- $translations := .AllTranslations | default .Site.Home.AllTranslations -}}
           {{ range $translations }}
@@ -135,6 +95,48 @@
         </div>
       </li>
       {{ end }}
+
+      <li class="navigation-item nav-section nav-theme" aria-label="Theme">
+        <button
+          type="button"
+          id="dark-mode-toggle"
+          title="{{ if $isZh }}切换深浅色主题{{ else }}Toggle color scheme{{ end }}"
+          aria-label="{{ if $isZh }}切换深浅色主题{{ else }}Toggle color scheme{{ end }}"
+          aria-pressed="false"
+          class="nav-icon-link nav-icon-button nav-theme-button"
+        >
+          <svg
+            class="inline dark-mode-icon"
+            width="1.2em"
+            height="1.2em"
+            preserveAspectRatio="xMidYMid meet"
+            viewBox="0 0 24 24"
+            style="vertical-align: sub;"
+            aria-hidden="true"
+            focusable="false"
+          >
+            <path
+              d="M10 7a7 7 0 0 0 12 4.9v.1c0 5.523-4.477 10-10 10S2 17.523 2 12S6.477 2 12 2h.1A6.979 6.979 0 0 0 10 7zm-6 5a8 8 0 0 0 15.062 3.762A9 9 0 0 1 8.238 4.938A7.999 7.999 0 0 0 4 12z"
+              fill="currentColor"
+            ></path>
+          </svg>
+          <svg
+            class="inline light-mode-icon"
+            width="1.2em"
+            height="1.2em"
+            preserveAspectRatio="xMidYMid meet"
+            viewBox="0 0 24 24"
+            style="vertical-align: sub;"
+            aria-hidden="true"
+            focusable="false"
+          >
+            <path
+              d="M12 18a6 6 0 1 1 0-12a6 6 0 0 1 0 12zm0-2a4 4 0 1 0 0-8a4 4 0 0 0 0 8zM11 1h2v3h-2V1zm0 19h2v3h-2v-3zM3.515 4.929l1.414-1.414L7.05 5.636L5.636 7.05L3.515 4.93zM16.95 18.364l1.414-1.414l2.121 2.121l-1.414 1.414l-2.121-2.121zm2.121-14.85l1.414 1.415l-2.121 2.121l-1.414-1.414l2.121-2.121zM5.636 16.95l1.414 1.414l-2.121 2.121l-1.414-1.414l2.121-2.121zM23 11v2h-3v-2h3zM4 11v2H1v-2h3z"
+              fill="currentColor"
+            ></path>
+          </svg>
+        </button>
+      </li>
     </ul>
   </section>
 </nav>

--- a/static/css/nav-hotfix.css
+++ b/static/css/nav-hotfix.css
@@ -132,6 +132,36 @@ body.colorscheme-dark #home-art-canvas[data-art="dots"] {
   }
 }
 
+/* The theme toggle is a standalone final navigation item on desktop. */
+.navigation .nav-theme {
+  display: flex;
+  align-items: center;
+}
+
+.navigation .nav-theme-button {
+  appearance: none;
+  -webkit-appearance: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--c-fg-deep);
+  font: inherit;
+  font-size: 1.6rem;
+  line-height: 1;
+  opacity: 0.6;
+  cursor: pointer;
+  transition: opacity 0.2s ease;
+}
+
+.navigation .nav-theme-button:hover,
+.navigation .nav-theme-button:focus-visible {
+  opacity: 1;
+}
+
 /* Mobile menu: main.css was hiding #menu-toggle and all non-icon nav items. Restore a real drawer. */
 #menu-toggle.menu-button {
   appearance: none;
@@ -309,5 +339,28 @@ body.colorscheme-dark #home-art-canvas[data-art="dots"] {
     padding: 0 1rem;
     font-size: 1.25rem;
     font-weight: 700;
+  }
+
+  .navigation .nav-theme {
+    display: flex !important;
+    align-items: center;
+    justify-content: flex-end;
+    width: 100% !important;
+    margin-top: 0.55rem;
+    padding-top: 0.8rem;
+    border-top: 1px solid var(--c-border);
+  }
+
+  .navigation .nav-theme-button {
+    width: 4.2rem;
+    height: 4.2rem;
+    min-width: 4.2rem;
+    min-height: 4.2rem;
+    border: 1px solid var(--c-border);
+    border-radius: 14px;
+    background: rgba(125, 125, 125, 0.045);
+    font-size: 1.45rem;
+    opacity: 0.88;
+    box-sizing: border-box;
   }
 }


### PR DESCRIPTION
## Changes
- add the missing English `long-term-investing` landing page so the Investing menu no longer resolves to the homepage
- reorder the English and Chinese primary navigation around the site's AI/creator focus
- move the color-scheme toggle to the far right, after RSS
- keep the theme toggle accessible in the mobile drawer
- bump the navigation stylesheet cache key

## Final desktop order
`Blog → AI Startup → AI Coding → Creator → Projects → Investing → About → Search → Photos → Language → Social links → RSS → Theme`

## Validation
- verified the updated Hugo menu weights
- verified the English section bundle exists at `content/long-term-investing/_index.md`
- verified the existing `dark-mode-toggle` ID remains unchanged for the current JavaScript binding