### PR TITLE
Fix RSS position in header navigation

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -82,10 +82,12 @@
       </li>
 
       {{ with .Site.Params.social }}
+        {{- $socialLinks := where . "name" "ne" "RSS" -}}
+        {{ with $socialLinks }}
       <li class="navigation-item nav-section nav-socials" aria-label="Social links">
         <span class="mobile-menu-section-label sr-only">Follow</span>
         <div class="nav-social-grid">
-          {{- range sort . -}}
+          {{- range sort . "weight" -}}
           <a href="{{ .url }}" target="_blank" rel="noopener" title="{{ .name }}" aria-label="{{ .name }}" class="nav-icon-link">
             {{ if .icon }}<i class="{{ .icon | replaceRE `fa-2x` `` }}" aria-hidden="true"></i>
             {{ else if .link }}<img src="{{ .link }}" alt="{{ .name }}" class="nav-icon-img" />
@@ -94,6 +96,20 @@
           {{- end -}}
         </div>
       </li>
+        {{ end }}
+
+        {{- range where . "name" "eq" "RSS" -}}
+      <li class="navigation-item nav-section nav-socials nav-rss" aria-label="RSS">
+        <span class="mobile-menu-section-label sr-only">RSS</span>
+        <div class="nav-social-grid">
+          <a href="{{ .url }}" target="_blank" rel="noopener" title="{{ .name }}" aria-label="{{ .name }}" class="nav-icon-link">
+            {{ if .icon }}<i class="{{ .icon | replaceRE `fa-2x` `` }}" aria-hidden="true"></i>
+            {{ else if .link }}<img src="{{ .link }}" alt="{{ .name }}" class="nav-icon-img" />
+            {{ end }}
+          </a>
+        </div>
+      </li>
+        {{- end -}}
       {{ end }}
 
       <li class="navigation-item nav-section nav-theme" aria-label="Theme">


### PR DESCRIPTION
## Changes
- render regular social links separately from RSS
- sort social links explicitly by `weight`
- render RSS as its own navigation item immediately before the theme toggle

## Final desktop tail order
`GitHub → Twitter → YouTube → Substack → RSS → Theme`

This fixes the previous implementation where RSS remained inside the social collection and its visible position was still controlled by the generic collection sort.