### PR TITLE
Sync English investing page with Chinese content

### DIFF
--- a/content/long-term-investing/_index.md
+++ b/content/long-term-investing/_index.md
@@ -2,7 +2,7 @@
 title: "Long-Term Investing & Family Cash Flow"
 date: 2026-07-09
 url: "/long-term-investing/"
-description: "Felix Mao's notes on long-term investing, family cash flow, asset allocation, mortgages, index funds, gold, bonds, and crypto assets."
+description: "Felix Mao's notes on long-term investing, asset allocation, family cash flow, mortgages, index funds, gold, and crypto assets. The focus is not on predicting markets, but on building a more resilient household financial system."
 tags:
   - Long-Term Investing
   - Family Cash Flow
@@ -12,71 +12,92 @@ tags:
 
 # Long-Term Investing & Family Cash Flow
 
-I am not trying to build a collection of isolated trades. I want to understand how an ordinary family can place income, a mortgage, emergency cash, index funds, bonds, gold, and crypto assets inside one coherent system.
+What I want to organize is not a collection of buy and sell records, but a system for how an ordinary family can place salary income, a mortgage, cash reserves, index funds, gold, and crypto assets within the same framework.
 
-It is easy to let a single asset dominate the conversation: whether an ETF is attractive, whether technology will keep outperforming, whether Bitcoin is still worth owning, or whether paying down a mortgage is safer than investing.
+I used to look at investing through individual assets and easily get pulled along by whichever one was in front of me.
 
-Over time, I have found that the more important question is not how to capture every opportunity. It is how to prevent the family's financial structure from becoming fragile.
+Is this ETF attractive? Will that industry keep rising? Is BTC still worth buying? Is gold too conservative? Should the mortgage be paid down early?
 
-Different assets should do different jobs:
+Over time, I realized that the most important thing for an ordinary family is not capturing every opportunity. It is avoiding a financial structure that becomes too fragile.
 
-- cash and short-term bonds provide liquidity and protection;
-- broad-market index funds form the long-term core;
-- technology funds and other concentrated positions provide growth exposure;
-- gold helps diversify extreme risks;
-- crypto assets remain a small, high-volatility allocation.
+Salary income, mortgage debt, cash reserves, index funds, gold, bonds, and crypto assets should be viewed on the same map.
 
-The purpose of this section is to document a long-term system that can continue through job changes, market drawdowns, higher family expenses, and changing financial goals.
+Some assets are responsible for growth, some for defense, some for liquidity and cash flow, and some are only small positions kept under observation.
 
-## Start with the family's real cash flow
+I am organizing this series to make those roles clearer. The point is not to predict the next market cycle, but to build a long-term investment system that is less likely to break when unemployment, market drawdowns, or higher family expenses occur.
 
-Investment capacity is not determined only by risk tolerance. It is also determined by whether the household can continue operating when risk becomes real.
+## First calculate it clearly: how much does a family need to be financially free?
 
-Before increasing exposure to volatile assets, I look at:
+Financial freedom is not one universal number. It depends on a family's real annual spending, the withdrawal rate it can accept, and how many years the assets need to support.
 
-- essential annual spending;
-- mortgage payments and other fixed obligations;
-- emergency reserves;
-- large expenses expected over the next few years;
-- the stability of employment income;
-- the possibility of being forced to sell during a market decline.
+If a family needs RMB 120,000 per year, a 4% initial withdrawal rate implies a basic target of roughly RMB 3 million. A more conservative 3% withdrawal rate implies roughly RMB 4 million. But those numbers do not automatically solve the mortgage, healthcare, children's education, parental support, or the number of years spent in early retirement.
 
-A portfolio can be reasonable in theory and still fail in practice if the family needs the money at the wrong time.
+The useful step is not memorizing “RMB 3 million.” It is putting current principal, annual contributions, return scenarios, and target annual spending into one model so the path can be tracked over time.
 
-> The ability to take risk does not come only from courage. It comes from having enough cash flow to stay invested after the risk appears.
+[Read the full article: Freedom is not just a dream. It is a number that can be calculated.](/zh-cn/wealth-freedom-calculation/)
 
-## Core assets and growth assets solve different problems
+## Core assets and growth assets: I no longer ask only which one has the higher return
 
-I used to treat the asset I liked most as the asset that deserved the largest allocation. That is not always the same as building a resilient portfolio.
+Long-term investing is often reduced to one question: should I buy relatively stable core assets, or concentrate on higher-growth assets such as the Nasdaq, VGT, BTC, and ETH?
 
-Broad-market funds are closer to core assets because they represent a wider part of the economy and depend less on one industry or trend. Technology funds can still be excellent growth assets, but they are more concentrated and more dependent on continued earnings growth and market expectations.
+David Swensen's view of “core assets” gave me a different way to think about this. A core asset is not simply the asset that rose the most in the past. It should represent a broad part of the economic system, generate long-term returns, and avoid depending too heavily on one industry or one trend.
 
-Crypto assets have even greater upside and downside. For a family portfolio, they are better treated as a limited high-risk allocation than as the foundation of the entire financial plan.
+By that standard, VTI, VOO, international equities, and bonds are closer to core assets. The Nasdaq and VGT are more growth-oriented. They benefit from the long-term development of mobile computing, cloud services, software, and AI, but they also depend more heavily on continued technology-sector growth and market expectations for future earnings.
 
-The roles are different:
+VGT is even more concentrated than the Nasdaq. It can be a high-quality technology growth position, but it cannot represent the whole market. BTC and ETH offer greater upside potential and also larger possible drawdowns. They are better suited to a small, high-risk allocation than to becoming the position that determines the family's entire financial outcome.
 
-- core assets help the portfolio survive for a long time;
-- growth assets aim for returns above the broad market;
-- family cash flow determines how much concentration the household can safely carry.
+This does not mean core assets are always better than growth assets. They solve different problems:
 
-> A growth asset can remain my highest-conviction investment without becoming the only asset responsible for my family's future.
+- core assets are responsible for helping the portfolio survive over the long term;
+- growth assets are responsible for seeking returns above the market average;
+- family cash flow determines how much concentration and aggression a household can afford.
 
-## Investing versus paying down the mortgage
+A family with stable income, sufficient emergency cash, a manageable mortgage, and no need to sell investments for living expenses over the next several years can tolerate more volatility from growth assets. In contrast, if income may be interrupted, family expenses are rising, or the household may be forced to sell during a market decline, an overly concentrated portfolio can fail midway even when the long-term thesis is correct.
 
-This decision cannot be reduced to comparing the mortgage rate with an expected market return.
+The real question is therefore not “Which is better, VOO or VGT?” It is what role each asset should play within the household financial system.
 
-Paying down debt provides certainty and lowers fixed obligations. Continuing to invest preserves liquidity and long-term growth potential. The better balance depends on job stability, cash reserves, family expenses, investment horizon, and the amount of volatility the household can actually tolerate.
+Cash and short-term bonds provide a safety buffer. Broad-market index funds form the long-term core. VGT and the Nasdaq provide technology growth exposure. BTC and ETH preserve the possibility of higher-risk, higher-upside returns. The exact allocation depends on the investment horizon, household debt, cash-flow stability, and the drawdown the investor can truly tolerate.
 
-My practical order is:
+I used to interpret “the asset I believe in most” as “the core asset that deserves the largest position.” Over time, I came to understand something different:
 
-1. keep enough liquidity for emergencies and near-term expenses;
-2. avoid a portfolio that would force selling during a downturn;
-3. maintain a diversified long-term core;
-4. use concentrated growth assets only within a clearly limited risk budget;
-5. revisit the balance when income, debt, or family responsibilities change.
+> VGT can remain my highest-conviction growth asset, but my family's core portfolio cannot be determined only by what I believe in most. It must also be determined by whether the household can keep operating even when my judgment is wrong.
 
-## What this section is for
+Family cash flow is not merely a lifestyle issue outside the portfolio. It is part of the portfolio itself.
 
-This section will cover concrete assets, accounts, allocation methods, and personal decisions. The goal is not to provide short-term trading instructions or predict the next market cycle.
+> The ability to take aggressive positions does not come only from being willing to accept risk. It also comes from having enough family cash flow to remain in the market after that risk actually appears.
 
-The goal is to build a reusable framework for deciding what each asset is supposed to do, how much risk the family can carry, and how to keep the plan running for many years.
+## Recommended reading
+
+- [Freedom is not just a dream. It is a number that can be calculated.](/zh-cn/wealth-freedom-calculation/)
+- [My asset-allocation checklist: putting every holding into eight baskets](/zh-cn/asset-allocation-library/)
+- [RWA: can the problem of gold having no cash flow be solved?](/zh-cn/rwa-gold-defi/)
+- [My crypto-asset watchlist: ETH, BNB, and AI Agent tokens](/zh-cn/crypto-assets-watchlist/)
+- [How options should be understood within an investment system](/zh-cn/options-basics/)
+- [My investment journey](/zh-cn/invest/)
+
+## FAQ
+
+### What matters most for an ordinary family doing long-term investing?
+
+The most important thing is not finding the fastest-rising asset. It is first stabilizing household cash flow and the overall asset structure. Emergency funds, the mortgage, daily expenses, insurance, and major spending expected over the next several years should be considered together with the investment accounts. Long-term investing only becomes real when the family does not need to sell during a market decline.
+
+### What roles should index funds, gold, bonds, and crypto assets play?
+
+Index funds mainly provide long-term growth. Cash and short-term bonds provide liquidity and defense. Gold helps diversify extreme risks. Crypto assets are better treated as a small, high-volatility allocation kept under observation. These assets are not substitutes for one another. They perform different jobs within the household financial system.
+
+### With a mortgage, should I pay it down early or continue investing?
+
+This cannot be decided only by comparing the mortgage rate with expected investment returns. Job stability, cash reserves, household spending, and personal tolerance for volatility also matter. Paying down the mortgage provides certainty, while continuing to invest preserves liquidity and long-term growth potential. A more practical approach is often to keep a sufficient cash reserve first, then dynamically balance the two.
+
+### Should a long-term investment plan change when markets fall sharply?
+
+If household cash flow has not changed and the asset allocation remains within the family's risk capacity, a market decline by itself is usually not a reason to rewrite the long-term plan. The situations that genuinely require adjustment are interrupted income, a clear increase in future spending, excessive concentration, or a change in the original risk assumptions.
+
+### Will this series include specific buy and sell recommendations?
+
+It will discuss specific assets, accounts, and allocation methods, but the focus is not on issuing short-term trading instructions. The goal is to explain each asset's role, use case, and risk within the household system, and to build a reusable framework rather than chase every market move.
+
+## Related topics
+
+- [AI Indie Hacking](/ai-indie-hacking/)
+- [Creator Workflow](/creator-workflow/)


### PR DESCRIPTION
## Changes
- replace the condensed English investing landing page with a faithful English version of the Chinese source page
- restore the financial-freedom section, the full core-vs-growth discussion, recommended reading, FAQ, and related topics
- keep links to the existing Chinese-only investing articles until English translations exist

## Validation
- both language versions now have the same section structure and the same substantive points
- the English page remains at `/long-term-investing/`