### PR TITLE
feat: add overseas SEO research pipeline MVP

### DIFF
--- a/scripts/seo_keyword_score.py
+++ b/scripts/seo_keyword_score.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Rank Semrush keyword exports for maoxunxing.com content research."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+import re
+import sys
+from pathlib import Path
+
+ALIASES = {
+    "keyword": {"keyword", "phrase", "search term", "query"},
+    "volume": {"volume", "search volume", "monthly volume"},
+    "kd": {"keyword difficulty", "keyword difficulty %", "kd", "kd %", "difficulty"},
+    "cpc": {"cpc", "cpc usd", "cpc (usd)", "cost per click"},
+    "intent": {"intent", "search intent"},
+    "relevance": {"relevance", "relevance score", "site relevance"},
+}
+
+INTENT_SCORES = {
+    "commercial": 100.0,
+    "transactional": 95.0,
+    "informational": 85.0,
+    "navigational": 50.0,
+    "c": 100.0,
+    "t": 95.0,
+    "i": 85.0,
+    "n": 50.0,
+}
+
+
+def normalize_header(value: str) -> str:
+    value = value.strip().lower().replace("_", " ")
+    return re.sub(r"\s+", " ", value)
+
+
+def resolve_columns(fieldnames: list[str]) -> dict[str, str | None]:
+    normalized = {normalize_header(name): name for name in fieldnames}
+    resolved: dict[str, str | None] = {}
+    for canonical, aliases in ALIASES.items():
+        resolved[canonical] = next(
+            (normalized[alias] for alias in aliases if alias in normalized), None
+        )
+    return resolved
+
+
+def parse_number(value: str | None, default: float = 0.0) -> float:
+    if value is None:
+        return default
+    cleaned = value.strip().replace(",", "").replace("%", "").replace("$", "")
+    if not cleaned:
+        return default
+    try:
+        return float(cleaned)
+    except ValueError:
+        return default
+
+
+def volume_score(volume: float) -> float:
+    # 10 -> ~26, 100 -> ~50, 1k -> ~75, 10k+ -> 100.
+    return min(100.0, 25.0 * math.log10(max(0.0, volume) + 1.0))
+
+
+def cpc_score(cpc: float, max_cpc: float) -> float:
+    if max_cpc <= 0:
+        return 50.0
+    return min(100.0, 100.0 * math.log1p(max(cpc, 0.0)) / math.log1p(max_cpc))
+
+
+def intent_score(intent: str | None) -> float:
+    if not intent:
+        return 70.0
+    raw = intent.strip().lower()
+    if not raw:
+        return 70.0
+    candidates = re.split(r"[,;/|+\s]+", raw)
+    scores = [INTENT_SCORES[item] for item in candidates if item in INTENT_SCORES]
+    return max(scores, default=70.0)
+
+
+def relevance_score(value: str | None) -> float:
+    score = parse_number(value, default=70.0)
+    return max(0.0, min(100.0, score))
+
+
+def rank_keywords(
+    rows: list[dict[str, str]], columns: dict[str, str | None]
+) -> list[dict[str, object]]:
+    keyword_col = columns["keyword"]
+    volume_col = columns["volume"]
+    kd_col = columns["kd"]
+    if not keyword_col or not volume_col or not kd_col:
+        missing = [name for name in ("keyword", "volume", "kd") if not columns[name]]
+        raise ValueError(
+            "Missing required Semrush columns: "
+            + ", ".join(missing)
+            + ". Expected Keyword, Volume, and Keyword Difficulty/KD."
+        )
+
+    max_cpc = max(
+        (parse_number(row.get(columns["cpc"])) for row in rows)
+        if columns["cpc"]
+        else [0.0],
+        default=0.0,
+    )
+
+    ranked: list[dict[str, object]] = []
+    for row in rows:
+        keyword = (row.get(keyword_col) or "").strip()
+        if not keyword:
+            continue
+        volume = max(0.0, parse_number(row.get(volume_col)))
+        kd = max(0.0, min(100.0, parse_number(row.get(kd_col))))
+        cpc = (
+            max(0.0, parse_number(row.get(columns["cpc"])))
+            if columns["cpc"]
+            else 0.0
+        )
+        intent = (row.get(columns["intent"]) or "").strip() if columns["intent"] else ""
+        relevance = (
+            relevance_score(row.get(columns["relevance"]))
+            if columns["relevance"]
+            else 70.0
+        )
+
+        components = {
+            "relevance": relevance,
+            "difficulty": 100.0 - kd,
+            "volume": volume_score(volume),
+            "intent": intent_score(intent),
+            "cpc": cpc_score(cpc, max_cpc),
+        }
+        opportunity = (
+            components["relevance"] * 0.30
+            + components["difficulty"] * 0.25
+            + components["volume"] * 0.20
+            + components["intent"] * 0.15
+            + components["cpc"] * 0.10
+        )
+        ranked.append(
+            {
+                "keyword": keyword,
+                "volume": int(volume) if volume.is_integer() else volume,
+                "kd": round(kd, 1),
+                "cpc": round(cpc, 2),
+                "intent": intent or "unknown",
+                "relevance": round(relevance, 1),
+                "opportunity_score": round(opportunity, 1),
+            }
+        )
+
+    return sorted(
+        ranked,
+        key=lambda item: (
+            -float(item["opportunity_score"]),
+            -float(item["volume"]),
+            float(item["kd"]),
+            str(item["keyword"]).lower(),
+        ),
+    )
+
+
+def read_csv(path: Path) -> tuple[list[dict[str, str]], list[str]]:
+    with path.open("r", encoding="utf-8-sig", newline="") as handle:
+        sample = handle.read(4096)
+        handle.seek(0)
+        try:
+            dialect = csv.Sniffer().sniff(sample, delimiters=",;\t")
+        except csv.Error:
+            dialect = csv.excel
+        reader = csv.DictReader(handle, dialect=dialect)
+        if not reader.fieldnames:
+            raise ValueError("CSV has no header row.")
+        return list(reader), list(reader.fieldnames)
+
+
+def write_csv(path: Path, rows: list[dict[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fields = [
+        "keyword",
+        "volume",
+        "kd",
+        "cpc",
+        "intent",
+        "relevance",
+        "opportunity_score",
+    ]
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def write_markdown(path: Path, rows: list[dict[str, object]], top: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# SEO Keyword Opportunities",
+        "",
+        "Generated from a Semrush CSV export. Scores are prioritization aids, not publishing decisions.",
+        "",
+        "| # | Keyword | Volume | KD | CPC | Intent | Relevance | Score |",
+        "|---:|---|---:|---:|---:|---|---:|---:|",
+    ]
+    for index, row in enumerate(rows[:top], start=1):
+        keyword = str(row["keyword"]).replace("|", "\\|")
+        intent = str(row["intent"]).replace("|", "\\|")
+        lines.append(
+            f"| {index} | {keyword} | {row['volume']} | {row['kd']} | "
+            f"{row['cpc']} | {intent} | {row['relevance']} | "
+            f"**{row['opportunity_score']}** |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Scoring",
+            "",
+            "- Site/content relevance: 30%",
+            "- Lower keyword difficulty: 25%",
+            "- Search volume: 20%",
+            "- Search intent: 15%",
+            "- CPC/commercial signal: 10%",
+            "",
+            "Before drafting, Codex should still check SERP intent, content gaps, and cannibalization against `content/`.",
+            "",
+        ]
+    )
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", type=Path, help="Semrush CSV export")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("seo/output/opportunities.csv"),
+        help="Ranked CSV output",
+    )
+    parser.add_argument(
+        "--markdown",
+        type=Path,
+        default=Path("seo/output/opportunities.md"),
+        help="Top opportunities Markdown report",
+    )
+    parser.add_argument("--top", type=int, default=30, help="Rows in Markdown report")
+    parser.add_argument("--min-volume", type=float, default=20.0)
+    parser.add_argument("--max-kd", type=float, default=70.0)
+    args = parser.parse_args()
+
+    try:
+        rows, fieldnames = read_csv(args.input)
+        columns = resolve_columns(fieldnames)
+        ranked = rank_keywords(rows, columns)
+    except (OSError, ValueError) as exc:
+        print(f"seo_keyword_score: {exc}", file=sys.stderr)
+        return 1
+
+    filtered = [
+        row
+        for row in ranked
+        if float(row["volume"]) >= args.min_volume and float(row["kd"]) <= args.max_kd
+    ]
+    write_csv(args.output, filtered)
+    write_markdown(args.markdown, filtered, max(1, args.top))
+    print(
+        f"Ranked {len(rows)} keywords; kept {len(filtered)} "
+        f"(volume >= {args.min_volume:g}, KD <= {args.max_kd:g})."
+    )
+    print(f"CSV: {args.output}")
+    print(f"Report: {args.markdown}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/seo/.gitignore
+++ b/seo/.gitignore
@@ -1,0 +1,2 @@
+input/
+output/

--- a/seo/CODEX_PROMPT.md
+++ b/seo/CODEX_PROMPT.md
@@ -1,0 +1,75 @@
+# Codex Prompt: Overseas SEO Research
+
+Use this prompt from the repository root after `seo/output/opportunities.md` exists.
+
+```text
+You are the SEO research and content-planning agent for maoxunxing.com, a Hugo site.
+
+Goal: identify a small number of English-language SEO opportunities that fit the site's real expertise. Do not mass-produce pages and do not publish anything automatically.
+
+Inputs:
+- seo/output/opportunities.md
+- seo/output/opportunities.csv
+- existing content under content/
+- repository instructions in AGENTS.md
+
+For the top keyword opportunities:
+
+1. Check site fit.
+   - Read relevant existing Chinese and English content.
+   - Reject keywords that do not fit the site's AI/engineering/investing expertise.
+   - Prefer topics where the author can add first-hand experience, calculations, frameworks, or original judgment.
+
+2. Check cannibalization.
+   - Search content/ for pages targeting the same query or search intent.
+   - If an existing English page already satisfies the intent, propose updating it instead of creating a new page.
+
+3. Research the live SERP.
+   - Identify the dominant search intent.
+   - Summarize what the leading results cover.
+   - Identify missing questions, weak explanations, stale information, or angles where maoxunxing.com can be genuinely better.
+   - Do not invent search-volume, ranking, backlink, or SERP facts.
+
+4. Select at most 3 topics.
+   For each topic create a brief under:
+   seo/briefs/YYYY-MM-DD/<slug>.md
+
+   Each brief must contain:
+   - Primary keyword
+   - Secondary/supporting keywords
+   - Search intent
+   - Target reader
+   - Why this topic fits maoxunxing.com
+   - Existing-site overlap / cannibalization result
+   - SERP summary
+   - Content gap / differentiated angle
+   - Proposed SEO title
+   - H1
+   - Suggested URL slug
+   - Meta description
+   - H2/H3 outline
+   - Questions/FAQ worth answering
+   - Internal links to existing maoxunxing.com content
+   - External primary sources needed for factual claims
+   - Original experience/data/judgment the author should add
+   - Risks or claims that require verification
+   - Recommendation: CREATE / UPDATE / REJECT
+
+5. Only create an article draft when the brief recommendation is CREATE or UPDATE and the differentiated angle is clear.
+   - For a new English article use the existing Hugo content conventions.
+   - Keep it as draft content until reviewed.
+   - Write for English-language search intent; do not mechanically translate the Chinese article.
+   - Use concise, natural English and answer the query early.
+   - Include useful internal links, an FAQ only when it helps the reader, and sources for time-sensitive or factual claims.
+   - Never manufacture personal experience, portfolio positions, results, quotes, statistics, or sources.
+
+6. Validation before proposing a PR:
+   - Follow AGENTS.md.
+   - Run the repository's relevant build/SEO checks when available.
+   - Report selected keywords, rejected keywords, created/updated files, verification gaps, and recommended next action.
+
+Human-review gate:
+- Do not merge.
+- Do not turn drafts live without explicit approval.
+- Quality and topic fit matter more than publishing volume.
+```

--- a/seo/README.md
+++ b/seo/README.md
@@ -1,0 +1,95 @@
+# Overseas SEO Research Workflow
+
+This directory is the human-review layer between Semrush keyword data and published content.
+
+The goal is **not** to mass-publish AI articles. The workflow is:
+
+1. Collect keyword data from Semrush.
+2. Rank opportunities by relevance, difficulty, volume, intent, and CPC.
+3. Let Codex inspect the existing `content/` tree for overlap/cannibalization.
+4. Research the current SERP before choosing a topic.
+5. Produce a content brief first.
+6. Create an English draft only when the topic has a clear search intent and a differentiated angle.
+7. Keep generated articles as drafts and review them before publishing.
+
+## MVP: use a Semrush CSV export
+
+Export keyword data from Semrush and save it locally, for example:
+
+```text
+seo/input/semrush.csv
+```
+
+The scorer requires these fields (common aliases are accepted):
+
+- `Keyword`
+- `Volume`
+- `Keyword Difficulty` or `KD %`
+
+Optional fields improve prioritization:
+
+- `CPC`
+- `Intent`
+- `Relevance` — a 0-100 manual score for how well the keyword fits maoxunxing.com
+
+Run:
+
+```bash
+python3 scripts/seo_keyword_score.py seo/input/semrush.csv
+```
+
+Outputs:
+
+```text
+seo/output/opportunities.csv
+seo/output/opportunities.md
+```
+
+Default filters:
+
+- minimum monthly search volume: 20
+- maximum KD: 70
+- Markdown report: top 30 keywords
+
+You can override them:
+
+```bash
+python3 scripts/seo_keyword_score.py seo/input/semrush.csv \
+  --min-volume 50 \
+  --max-kd 55 \
+  --top 20
+```
+
+## Opportunity score
+
+The current MVP score is deliberately simple and explainable:
+
+| Signal | Weight |
+| --- | ---: |
+| Site/content relevance | 30% |
+| Lower keyword difficulty | 25% |
+| Search volume | 20% |
+| Search intent | 15% |
+| CPC/commercial signal | 10% |
+
+Do not publish based on the score alone. A high-scoring keyword can still be a bad target if the SERP intent does not match the site, the topic is already covered, or the result requires authority/data the site cannot credibly provide.
+
+## Recommended first topic pools
+
+Start from areas where the site already has first-hand knowledge and supporting internal content:
+
+- AI coding workflows / AI engineering
+- AI indie hacking / micro-SaaS building
+- long-term investing and household asset allocation
+- options education for long-term investors
+- gold / RWA / portfolio construction
+
+Existing Chinese posts can be used as research material, but English pages should be rewritten for English-language search intent rather than translated mechanically.
+
+## What Codex should do next
+
+Use [`CODEX_PROMPT.md`](./CODEX_PROMPT.md) after the opportunity report has been generated. Codex should select only a small number of topics, inspect current site content, research the SERP, and create briefs before drafting pages.
+
+## Next automation step
+
+Once the Semrush API/connector is callable in the execution environment, replace the manual CSV export with an automated data-fetch step. Keep the scorer, cannibalization check, brief stage, and human review gate unchanged.


### PR DESCRIPTION
## What this starts

Adds a low-risk MVP for overseas SEO research before any automatic publishing.

### Included
- `scripts/seo_keyword_score.py`: reads a Semrush CSV export and ranks keyword opportunities by relevance, lower KD, volume, intent, and CPC.
- `seo/README.md`: documents the workflow and first topic pools.
- `seo/CODEX_PROMPT.md`: gives Codex a repository-aware workflow for cannibalization checks, live SERP research, content briefs, and draft-only article creation.
- `seo/.gitignore`: keeps Semrush input/output data out of Git.

## Safety / quality gates
- No mass publishing.
- Max 3 selected topics per research run.
- Check existing `content/` before creating pages.
- Research live SERP before drafting.
- Drafts require human review and must not be merged automatically.
- Do not invent Semrush/SERP data, sources, personal experience, or portfolio facts.

## Current limitation
The Semrush plugin is connected in ChatGPT, but its callable API did not surface in the current session. The MVP therefore accepts Semrush CSV immediately; the next iteration can replace that input step with direct Semrush API/connector fetching without changing the ranking/brief/review pipeline.

## Validation
The keyword scoring script was exercised against a representative local CSV fixture and successfully generated ranked CSV + Markdown outputs. Full repository build validation was not run because this environment cannot clone GitHub over the container network.
