### PR TITLE
fix: normalize Algolia search URLs to Hugo permalinks

### DIFF
--- a/layouts/partials/docSearch.html
+++ b/layouts/partials/docSearch.html
@@ -2,6 +2,38 @@
 
 <script>
   const docsearch = window.docsearch;
+
+  const sectionPermalinkPrefixes = [
+    "notes",
+    "posts",
+    "projects",
+    "book-reports",
+    "prompts",
+    "long-term-investing",
+    "about",
+    "uses",
+    "bookmarks",
+    "media",
+    "streams",
+    "demos",
+    "gallery",
+    "raw",
+  ];
+
+  function normalizeSearchUrl(url) {
+    if (!url) return url;
+
+    const pathname = new URL(url, window.location.origin).pathname;
+    const segments = pathname.split("/").filter(Boolean);
+
+    // Keep language prefix, remove Hugo content section prefixes.
+    if (segments.length >= 3 && sectionPermalinkPrefixes.includes(segments[1])) {
+      return `/${segments[0]}/${segments.slice(2).join("/")}/`;
+    }
+
+    return url;
+  }
+
   docsearch({
     container: "#docsearch",
     appId: "D7NQ3RODEC",
@@ -10,6 +42,7 @@
     transformItems(items) {
       return items.map((item) => ({
         ...item,
+        url: normalizeSearchUrl(item.url),
         content: item.content.toUpperCase(),
       }));
     },


### PR DESCRIPTION
## Problem

Algolia search results were linking to source content paths such as `/zh-cn/notes/economic`, while Hugo publishes these pages using flattened permalinks like `/zh-cn/economic`.

## Changes

- Normalize search result URLs before navigation.
- Remove source section prefixes from Algolia URLs.
- Keep search behavior consistent with Hugo permalink configuration.

## Impact

Fixes broken links from the navbar search experience without requiring immediate Algolia index regeneration.