### PR TITLE
Simplify homepage and make Chinese the default

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,8 +1,9 @@
 baseurl = "https://maoxunxing.com/"
 title = "maoxunxing"
 theme = "hugo-coder"
-languagecode = "en"
-defaultcontentlanguage = "en"
+languagecode = "zh-CN"
+defaultcontentlanguage = "zh-CN"
+defaultcontentlanguageinsubdir = true
 canonifyurls = false
 timeout = 120000
 googleAnalytics = "UA-199510588-1"
@@ -18,7 +19,7 @@ pygmentscodefencesguesssyntax = true
 
 [languages]
   [languages.zh-CN]
-    weight = 2
+    weight = 1
     languageName = "CN"
     title = "毛毛星 Felix Mao - AI 创作者、前端工程师与独立开发者"
     [languages.zh-CN.params]
@@ -29,7 +30,7 @@ pygmentscodefencesguesssyntax = true
       custom_js = ["/js/home-dots-simplex.js?v=20260710b", "/js/code-copy.js?v=20260713a"]
   [languages.en]
     languageName = "EN"
-    weight = 1
+    weight = 2
     title = "Felix Mao - AI Creator, Frontend Engineer & Indie Hacker"
     [languages.en.params]
       description = "Felix Mao's personal knowledge site about AI coding, AI indie hacking, frontend engineering, creator workflows, systems thinking, and long-term investing."

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -22,6 +22,9 @@ other = "Hi, I'm Felix Mao"
 [homeHeroDesc]
 other = "I spent a decade writing frontend code. Recently, I have been learning AI seriously, building small personal products, and keeping notes on long-term investing and family cash flow. I keep writing down the things I actually used, thought about, and struggled with here."
 
+[homeQuickLinks]
+other = """You can read my <a href="/en/notes/">notes</a>, browse the <a href="/en/gallery/">gallery</a>, see the <a href="/en/uses/">hardware and software I use</a>, explore my <a href="/en/bookmarks/">curated bookmarks</a>, and visit my <a href="/en/media/">books and media</a>."""
+
 [homePrimaryCTA]
 other = "Start with the blog"
 

--- a/i18n/zh-cn.toml
+++ b/i18n/zh-cn.toml
@@ -22,6 +22,9 @@ other = "Hi，我是毛毛星"
 [homeHeroDesc]
 other = "写了十年前端，最近在认真学习 AI、做个人产品，也记录长期投资和家庭现金流。我会把自己真正用过、想过、踩过坑的东西，慢慢写在这里。"
 
+[homeQuickLinks]
+other = """你可以读我的<a href="/zh-cn/notes/">随笔</a>、看看<a href="/zh-cn/gallery/">画廊</a>、我使用的<a href="/zh-cn/uses/">软硬件装备</a>、我整理的<a href="/zh-cn/bookmarks/">书签收藏</a>，以及我的<a href="/zh-cn/media/">书影音</a>。"""
+
 [homePrimaryCTA]
 other = "从博客开始"
 

--- a/layouts/partials/home.html
+++ b/layouts/partials/home.html
@@ -2,7 +2,7 @@
      The stylesheet is also loaded from config.toml, but this explicit versioned
      link prevents stale language-specific pages from rendering the new homepage
      structure without the matching CSS. -->
-<link rel="stylesheet" href="/css/home.css?v=20260709-latest-writing-align1" />
+<link rel="stylesheet" href="/css/home.css?v=20260821-simple-home" />
 <style>
   #home-art-canvas {
     position: fixed !important;
@@ -42,16 +42,7 @@
     <p class="home-eyebrow">{{ i18n "homeEyebrow" | safeHTML }}</p>
     <h1 id="home-hero-title" class="home-hero-title">{{ i18n "homeHeroTitle" | safeHTML }}</h1>
     <p class="home-hero-desc">{{ i18n "homeHeroDesc" | safeHTML }}</p>
-    <div class="home-hero-actions">
-      <a class="home-action-primary" href="{{ i18n "homePrimaryHref" }}">{{ i18n "homePrimaryCTA" }}</a>
-      <a class="home-action-secondary" href="{{ i18n "homeSecondaryHref" }}">{{ i18n "homeSecondaryCTA" }}</a>
-    </div>
-  </section>
-
-  <section class="home-human-panel" aria-label="{{ i18n "homeIntroLabel" }}">
-    <p>{{ i18n "homeBio" | safeHTML }}</p>
-    <p>{{ i18n "homePara1" | safeHTML }}</p>
-    <p>{{ i18n "homePara3" | safeHTML }}</p>
+    <p class="home-quick-links">{{ i18n "homeQuickLinks" | safeHTML }}</p>
   </section>
 
   <section class="home-section-block home-start-block">

--- a/static/css/home.css
+++ b/static/css/home.css
@@ -35,11 +35,16 @@
   color: var(--c-fg);
 }
 
-.home-hero-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
-  margin: 1.8rem 0 0;
+.home-quick-links {
+  max-width: 62ch;
+  margin: 0;
+  color: var(--c-fg);
+  font-size: 1.4rem;
+  line-height: 1.75;
+}
+
+.home-quick-links a {
+  font-weight: 600;
 }
 
 .home-action-primary,
@@ -74,30 +79,6 @@
   transform: translateY(-1px);
   border-color: var(--c-border-hover);
   text-decoration: none;
-}
-
-.home-human-panel {
-  max-width: 72ch;
-  margin: 0 0 2.6rem;
-  padding: 1.35rem 1.5rem;
-  border: 1px solid var(--c-border);
-  border-radius: 18px;
-  background: rgba(125, 125, 125, 0.03);
-}
-
-.home-human-panel p {
-  margin: 0 0 1rem;
-  color: var(--c-fg);
-  font-size: 1.45rem;
-  line-height: 1.75;
-}
-
-.home-human-panel p:last-child {
-  margin-bottom: 0;
-}
-
-.home-human-panel a {
-  font-weight: 600;
 }
 
 .home-start-grid {
@@ -283,7 +264,6 @@ body.page-home .home-prose .article-section-tag {
   white-space: nowrap;
 }
 
-body.colorscheme-dark .home-human-panel,
 body.colorscheme-dark .home-start-card,
 body.colorscheme-dark .home-browse-link,
 body.colorscheme-dark .home-book-card {
@@ -306,7 +286,6 @@ body.colorscheme-dark .home-action-secondary {
 }
 
 @media (prefers-color-scheme: dark) {
-  body.colorscheme-auto .home-human-panel,
   body.colorscheme-auto .home-start-card,
   body.colorscheme-auto .home-browse-link,
   body.colorscheme-auto .home-book-card {
@@ -366,21 +345,7 @@ body.colorscheme-dark .home-action-secondary {
     line-height: 1.65;
   }
 
-  .home-hero-actions {
-    flex-direction: column;
-    margin-top: 1.1rem;
-  }
-
-  .home-action-primary,
-  .home-action-secondary {
-    width: 100%;
-  }
-
-  .home-human-panel {
-    padding: 1rem;
-  }
-
-  .home-human-panel p {
+  .home-quick-links {
     font-size: 1.35rem;
     line-height: 1.68;
   }


### PR DESCRIPTION
## Summary
- simplify the homepage hero by removing the two CTA buttons and bordered introduction panel
- keep the requested Notes, Gallery, Uses, Bookmarks, and Books & Media links as a compact sentence
- make Chinese the default language while preserving `/zh-cn/` URLs through a root redirect
- update the homepage stylesheet cache key

## Validation
- `git diff --check` passes
- Hugo 0.165.0 rendered `/zh-cn/index.html`; verified all five requested link labels and URLs
- verified `/index.html` redirects to `/zh-cn/`

## Existing build issues
- `npm run build` stops in the gallery generator because the checked-in image files cannot be decoded in this environment and fewer than 200 conversions succeed
- Hugo 0.111.3 (required by `AGENTS.md`) fails on the existing `hugo.IsServer` template usage
- Hugo 0.165.0 continues past the homepage but later fails on an existing image with an unknown format (`content/book-reports/my-genius-girlfriend/bg.jpeg`)